### PR TITLE
Avoid erroneous z-clipping near -1 and 1 in Web UI

### DIFF
--- a/ui-web/js/webglspins.js
+++ b/ui-web/js/webglspins.js
@@ -668,7 +668,15 @@ WebGLSpins._ArrowRenderer.prototype.draw = function(width, height) {
     gl.uniformMatrix4fv(gl.getUniformLocation(this._program, "uModelviewMatrix"), false, WebGLSpins._toFloat32Array(modelviewMatrix));
     var lightPosition = WebGLSpins._matrixMultiply(modelviewMatrix, this._options.cameraLocation);
     gl.uniform3f(gl.getUniformLocation(this._program, "uLightPosition"), lightPosition[0], lightPosition[1], lightPosition[2]);
-    gl.uniform2f(gl.getUniformLocation(this._program, "uZRange"), this._options.zRange[0], this._options.zRange[1]);
+    var zMin = this._options.zRange[0];
+    var zMax = this._options.zRange[1];
+    if (zMin <= -1.0) {
+        zMin = -2.0;
+    }
+    if (zMax >= 1.0) {
+        zMax = 2.0;
+    }
+    gl.uniform2f(gl.getUniformLocation(this._program, "uZRange"), zMin, zMax);
 
     gl.drawElementsInstanced(gl.TRIANGLES, this._numIndices, gl.UNSIGNED_SHORT, null, this._numInstances);
     this._boundingBoxRenderer.draw(width, height);
@@ -984,7 +992,15 @@ WebGLSpins._SurfaceRenderer.prototype.draw = function(width, height) {
     gl.uniformMatrix4fv(gl.getUniformLocation(this._program, "uProjectionMatrix"), false, WebGLSpins._toFloat32Array(projectionMatrix));
     var modelviewMatrix = WebGLSpins._lookAtMatrix(this._options.cameraLocation, this._options.centerLocation, this._options.upVector);
     gl.uniformMatrix4fv(gl.getUniformLocation(this._program, "uModelviewMatrix"), false, WebGLSpins._toFloat32Array(modelviewMatrix));
-    gl.uniform2f(gl.getUniformLocation(this._program, "uZRange"), this._options.zRange[0], this._options.zRange[1]);
+    var zMin = this._options.zRange[0];
+    var zMax = this._options.zRange[1];
+    if (zMin <= -1.0) {
+        zMin = -2.0;
+    }
+    if (zMax >= 1.0) {
+        zMax = 2.0;
+    }
+    gl.uniform2f(gl.getUniformLocation(this._program, "uZRange"), zMin, zMax);
 
     gl.disable(gl.CULL_FACE);
     gl.drawElements(gl.TRIANGLES, this._numIndices, gl.UNSIGNED_INT, null);
@@ -1186,7 +1202,15 @@ WebGLSpins._SphereRenderer.prototype.draw = function(width, height) {
     gl.uniformMatrix4fv(gl.getUniformLocation(this._program, "uProjectionMatrix"), false, WebGLSpins._toFloat32Array(projectionMatrix));
     var modelviewMatrix = WebGLSpins._lookAtMatrix(WebGLSpins._normalize(WebGLSpins._difference(this._options.cameraLocation, this._options.centerLocation)), [0, 0, 0], this._options.upVector);
     gl.uniformMatrix4fv(gl.getUniformLocation(this._program, "uModelviewMatrix"), false, WebGLSpins._toFloat32Array(modelviewMatrix));
-    gl.uniform2f(gl.getUniformLocation(this._program, "uZRange"), this._options.zRange[0], this._options.zRange[1]);
+    var zMin = this._options.zRange[0];
+    var zMax = this._options.zRange[1];
+    if (zMin <= -1.0) {
+        zMin = -2.0;
+    }
+    if (zMax >= 1.0) {
+        zMax = 2.0;
+    }
+    gl.uniform2f(gl.getUniformLocation(this._program, "uZRange"), zMin, zMax);
     gl.uniform2f(gl.getUniformLocation(this._program, "uPointSizeRange"), Math.floor(this._options.pointSizeRange[0]), Math.floor(this._options.pointSizeRange[1]));
     gl.uniform1f(gl.getUniformLocation(this._program, "uAspectRatio"), width / height);
     gl.uniform1f(gl.getUniformLocation(this._program, "uInnerSphereRadius"), this._options.innerSphereRadius);


### PR DESCRIPTION
Setting the minimum z to -1 or the maximum z to 1 should disable filtering in the corresponding direction, however numerical imprecision can lead to (0, 0, 1) or (0, 0, -1) spins being filtered out. This commit prevents this by replacing the -1 and 1 limits by -2 and 2 (arbitrary values of significantly larger magnitude).