### PR TITLE
Quick n dirty fix for Intel Compiler Error (Possible bug)

### DIFF
--- a/core/include/engine/Vectormath.hpp
+++ b/core/include/engine/Vectormath.hpp
@@ -411,17 +411,21 @@ namespace Engine
             auto& n_cell_atoms_old = geometry_old.n_cell_atoms;
 
             auto& n_cells_new = geometry_new.n_cells;
+            // As a workaround for compatibility with the intel compiler, the loop boundaries are copied to a local array;
+            //  not sure whether the "parallel loops with collapse must be perfectly nested" error (without this) is a compiler bug or standard conform behaviour
+            const int n_cells_new_local_copy[] = {geometry_new.n_cells[0],geometry_new.n_cells[1],geometry_new.n_cells[2]};
+
             auto& n_cell_atoms_new = geometry_new.n_cell_atoms;
 
             int N_new = n_cell_atoms_new * n_cells_new[0] * n_cells_new[1] * n_cells_new[2];
             field<T> newfield(N_new, default_value);
 
             #pragma omp parallel for collapse(3)
-            for (int i=0; i<n_cells_new[0]; ++i)
+            for (int i=0; i<n_cells_new_local_copy[0]; ++i)
             {
-                for (int j=0; j<n_cells_new[1]; ++j)
+                for (int j=0; j<n_cells_new_local_copy[1]; ++j)
                 {
-                    for (int k=0; k<n_cells_new[2]; ++k)
+                    for (int k=0; k<n_cells_new_local_copy[2]; ++k)
                     {
                         for (int iatom=0; iatom<n_cell_atoms_new; ++iatom)
                         {


### PR DESCRIPTION
### Contributor checklist
- [X] I have branched from the `develop` branch
- [X] My commit is 1 nicest logical chunk
- [X] My contribution is a half-baked and dirty hack, but should be merged as is!

------------------------------

### Description
PR #422 redone to start on and be merged into the `develop` branch:

Dirty fix for bug occuring with Intel Compiler (Versions 17, 18, 19b) and OpenMP preventing Compilation
Tested for successfull compilation (/w OpenMP but without CUDA) with:
- [X] Intel 18, 18.0.3.222,19_beta
- [X] gcc 7, 8
- [x] clang 5, 6

on centos-release-7-4.1708.el7.centos.x86_64

The Problem seems to be somewhere between the Intel Compiler and the `n_cells_new`, which is referenced from a `const Geometry &`. Using a local `const int` copy for the loops fixes the problem.

This Code fails to compile on:
- [ ] Intel 17: due to different problems: `[ 71%] Building CXX object core/CMakeFiles/Spirit.dir/src/utility/Timing.cpp.o Internal error loop: assertion failed: find_seq_in_lookup_table: seq_number not found (shared/cfe/edgcpfe/il.c, line 4094)`

