### PR TITLE
Reworked FFT_Plan() to address issues with copying

### DIFF
--- a/core/include/engine/FFT.hpp
+++ b/core/include/engine/FFT.hpp
@@ -159,7 +159,7 @@ namespace Engine
         {
             std::vector<int> dims;
             bool inverse;
-            int howmany;
+            int n_transforms;
 
             field<FFT_cpx_type> cpx_ptr;
             field<FFT_real_type> real_ptr;
@@ -175,12 +175,12 @@ namespace Engine
             FFT_Plan() : FFT_Plan({2,2,2}, true, 1, 8)
             {} 
 
-            FFT_Plan(std::vector<int> dims, bool inverse, int howmany, int len) :
+            FFT_Plan(std::vector<int> dims, bool inverse, int n_transforms, int len) :
                 dims(dims),
                 inverse(inverse),
-                howmany(howmany),
-                real_ptr(field<FFT::FFT_real_type>(howmany * len )),
-                cpx_ptr(field<FFT::FFT_cpx_type> (howmany * len))
+                n_transforms(n_transforms),
+                real_ptr(field<FFT::FFT_real_type>(n_transforms * len )),
+                cpx_ptr(field<FFT::FFT_cpx_type> (n_transforms * len))
 
             {
                 this->Create_Configuration();
@@ -191,7 +191,7 @@ namespace Engine
             {
                 this->dims     = other.dims;
                 this->inverse  = other.inverse;
-                this->howmany  = other.howmany;
+                this->n_transforms  = other.n_transforms;
                 this->name     = other.name;
                 this->cpx_ptr  = other.cpx_ptr;
                 this->real_ptr = other.real_ptr;
@@ -206,7 +206,7 @@ namespace Engine
                 {
                     this->dims     = other.dims;
                     this->inverse  = other.inverse;
-                    this->howmany  = other.howmany;
+                    this->n_transforms  = other.n_transforms;
                     this->name     = other.name;
                     this->cpx_ptr  = other.cpx_ptr;
                     this->real_ptr = other.real_ptr;
@@ -227,7 +227,7 @@ namespace Engine
                 {
                     this->dims     = std::move(other.dims);
                     this->inverse  = std::move(other.inverse);
-                    this->howmany  = std::move(other.howmany);
+                    this->n_transforms  = std::move(other.n_transforms);
                     this->name     = std::move(other.name);
                     this->cpx_ptr  = std::move(other.cpx_ptr);
                     this->real_ptr = std::move(other.real_ptr);

--- a/core/include/engine/FFT.hpp
+++ b/core/include/engine/FFT.hpp
@@ -214,7 +214,6 @@ namespace Engine
                     this->cpx_ptr.shrink_to_fit();
                     this->real_ptr.shrink_to_fit();
 
-                    // FFTW_DESTROY_PLAN(this->cfg);
                     this->Free_Configuration();
                     this->Create_Configuration();
                 }
@@ -233,10 +232,9 @@ namespace Engine
                     this->cpx_ptr  = std::move(other.cpx_ptr);
                     this->real_ptr = std::move(other.real_ptr);
 
-                    // this->cpx_ptr.shrink_to_fit();
-                    // this->real_ptr.shrink_to_fit();
+                    this->cpx_ptr.shrink_to_fit();
+                    this->real_ptr.shrink_to_fit();
 
-                    // FFTW_DESTROY_PLAN(this->cfg);
                     this->Free_Configuration();
                     this->Create_Configuration();
                 }

--- a/core/include/engine/Hamiltonian_Heisenberg.hpp
+++ b/core/include/engine/Hamiltonian_Heisenberg.hpp
@@ -157,8 +157,9 @@ namespace Engine
 
         // Plans for FT / rFT
         FFT::FFT_Plan fft_plan_spins;
-        FFT::FFT_Plan fft_plan_dipole;
         FFT::FFT_Plan fft_plan_reverse;
+
+        field<FFT::FFT_cpx_type> transformed_dipole_matrices;
 
         bool save_dipole_matrices = true;
         field<Matrix3> dipole_matrices;
@@ -177,7 +178,7 @@ namespace Engine
         FFT::StrideContainer dipole_stride;
 
         //Calculate the FT of the padded D matriess
-        void FFT_Dipole_Matrices(int img_a, int img_b, int img_c);
+        void FFT_Dipole_Matrices(FFT::FFT_Plan & fft_plan_dipole, int img_a, int img_b, int img_c);
         //Calculate the FT of the padded spins
         void FFT_Spins(const vectorfield & spins);
 

--- a/core/src/engine/FFT.cpp
+++ b/core/src/engine/FFT.cpp
@@ -34,8 +34,8 @@ namespace Engine
         {
             int rank = this->dims.size();
             int *n = this->dims.data();
-            int howmany = this->howmany;
-            int istride = howmany, ostride = howmany;
+            int n_transforms = this->n_transforms;
+            int istride = n_transforms, ostride = n_transforms;
             int *inembed = n, *onembed = n;
             
             int size = 1;
@@ -45,9 +45,9 @@ namespace Engine
             int idist = 1, odist = 1;
          
             if(this->inverse == false)
-                this->cfg = FFTW_PLAN_MANY_DFT_R2C(rank, n, howmany, this->real_ptr.data(), inembed, istride, idist, reinterpret_cast<FFTW_COMPLEX*>(this->cpx_ptr.data()), onembed, ostride, odist, FFTW_MEASURE);
+                this->cfg = FFTW_PLAN_MANY_DFT_R2C(rank, n, n_transforms, this->real_ptr.data(), inembed, istride, idist, reinterpret_cast<FFTW_COMPLEX*>(this->cpx_ptr.data()), onembed, ostride, odist, FFTW_MEASURE);
             else
-                this->cfg = FFTW_PLAN_MANY_DFT_C2R(rank, n, howmany, reinterpret_cast<FFTW_COMPLEX*>(this->cpx_ptr.data()), inembed, istride, idist, this->real_ptr.data(), onembed, ostride, odist, FFTW_MEASURE);
+                this->cfg = FFTW_PLAN_MANY_DFT_C2R(rank, n, n_transforms, reinterpret_cast<FFTW_COMPLEX*>(this->cpx_ptr.data()), inembed, istride, idist, this->real_ptr.data(), onembed, ostride, odist, FFTW_MEASURE);
         }
 
         void FFT_Plan::Free_Configuration()
@@ -78,7 +78,7 @@ namespace Engine
 
         void batch_Four_3D(FFT_Plan & plan)
         {
-            int number = plan.howmany;
+            int number = plan.n_transforms;
             int size = 1;
             for(auto k : plan.dims)
                 size *= k;
@@ -97,7 +97,7 @@ namespace Engine
         //same as above but iFFT
         void batch_iFour_3D(FFT_Plan & plan)
         {
-            int number = plan.howmany;
+            int number = plan.n_transforms;
             int size = 1;
             for(auto k : plan.dims)
                 size *= k;

--- a/core/src/engine/FFT.cpp
+++ b/core/src/engine/FFT.cpp
@@ -60,11 +60,6 @@ namespace Engine
             this->cpx_ptr = field<FFT_cpx_type>();
             this->real_ptr = field<FFT_real_type>();
             Free_Configuration();
-        }x
-
-        FFT_Plan::Free_Configuration()
-        {
-            FFTW_DESTROY_PLAN(this->cfg);
         }
         #endif //end fftw_backend
 

--- a/core/src/engine/FFT.cpp
+++ b/core/src/engine/FFT.cpp
@@ -23,13 +23,11 @@ namespace Engine
         void batch_Four_3D(FFT_Plan & plan)
         {
             FFTW_EXECUTE(plan.cfg);
-            // fftw_execute(plan.cfg);
         }
 
         void batch_iFour_3D(FFT_Plan & plan)
         {
             FFTW_EXECUTE(plan.cfg);
-            // fftw_execute(plan.cfg);
         }
 
         void FFT_Plan::Create_Configuration()
@@ -45,23 +43,16 @@ namespace Engine
                 size *= k;
 
             int idist = 1, odist = 1;
-
+         
             if(this->inverse == false)
-                // this->cfg = fftw_plan_many_dft_r2c(rank, n, howmany, this->real_ptr.data(), inembed, istride, idist, reinterpret_cast<fftw_complex*>(this->cpx_ptr.data()), onembed, ostride, odist, FFTW_MEASURE);
                 this->cfg = FFTW_PLAN_MANY_DFT_R2C(rank, n, howmany, this->real_ptr.data(), inembed, istride, idist, reinterpret_cast<FFTW_COMPLEX*>(this->cpx_ptr.data()), onembed, ostride, odist, FFTW_MEASURE);
             else
                 this->cfg = FFTW_PLAN_MANY_DFT_C2R(rank, n, howmany, reinterpret_cast<FFTW_COMPLEX*>(this->cpx_ptr.data()), inembed, istride, idist, this->real_ptr.data(), onembed, ostride, odist, FFTW_MEASURE);
-            this->freeable = true;
         }
 
         void FFT_Plan::Free_Configuration()
         {
-            if(freeable)
-            {
-                // fftw_destroy_plan(this->cfg);
-                FFTW_DESTROY_PLAN(this->cfg);
-                this->freeable = false;
-            }
+            FFTW_DESTROY_PLAN(this->cfg);
         }
 
         void FFT_Plan::Clean()
@@ -69,19 +60,13 @@ namespace Engine
             this->cpx_ptr = field<FFT_cpx_type>();
             this->real_ptr = field<FFT_real_type>();
             Free_Configuration();
-        }
+        }x
 
-        // FFT_Plan::FFT_Plan(std::string name) : name(name) {
-
-        //     std::cerr << "Calling constructor " << name << std::endl;
-        // }
-
-        FFT_Plan::~FFT_Plan()
+        FFT_Plan::Free_Configuration()
         {
-            // std::cerr << "Calling Destructor " << name << std::endl;
+            FFTW_DESTROY_PLAN(this->cfg);
         }
-
-        #endif
+        #endif //end fftw_backend
 
 
         //=== Functions for kissFFT backend ===
@@ -98,7 +83,6 @@ namespace Engine
 
         void batch_Four_3D(FFT_Plan & plan)
         {
-            // std::cerr << "Calling batch Four" << std::endl;
             int number = plan.howmany;
             int size = 1;
             for(auto k : plan.dims)
@@ -133,30 +117,13 @@ namespace Engine
         void FFT_Plan::Create_Configuration()
         {
             this->cfg = kiss_fftndr_alloc(this->dims.data(), this->dims.size(), this->inverse, NULL, NULL);
-            this->freeable = true;
         }
 
         void FFT_Plan::Free_Configuration()
         {
-            if(freeable)
-            {
-                free(this->cfg);
-                this->freeable = false;
-            }
+            free(this->cfg);
         }
-
-        void FFT_Plan::Clean()
-        {
-            this->cpx_ptr = field<FFT_cpx_type>();
-            this->real_ptr = field<FFT_real_type>();
-            Free_Configuration();
-        }
-
-        FFT_Plan::~FFT_Plan()
-        {
-            // std::cerr << "Calling Destructor " << name << std::endl;
-        }
-        #endif
+        #endif //end kiss_fft backend
     }
 }
 #endif

--- a/core/src/engine/FFT.cu
+++ b/core/src/engine/FFT.cu
@@ -31,8 +31,8 @@ namespace Engine
         {
             int rank = this->dims.size();
             int *n = this->dims.data();
-            int howmany = this->howmany;
-            int istride = howmany, ostride = howmany;
+            int n_transforms = this->n_transforms;
+            int istride = n_transforms, ostride = n_transforms;
             int *inembed = n, *onembed = n;
             
             int size = 1;
@@ -44,10 +44,10 @@ namespace Engine
 
             if(this->inverse == false)
             {
-                cufftPlanMany(&this->cfg, rank, n, inembed, istride, idist, onembed, ostride, odist, CUFFT_R2C, howmany);
+                cufftPlanMany(&this->cfg, rank, n, inembed, istride, idist, onembed, ostride, odist, CUFFT_R2C, n_transforms);
             } else 
             {
-                cufftPlanMany(&this->cfg, rank, n, inembed, istride, idist, onembed, ostride, odist, CUFFT_C2R, howmany);
+                cufftPlanMany(&this->cfg, rank, n, inembed, istride, idist, onembed, ostride, odist, CUFFT_C2R, n_transforms);
             }
         }
 

--- a/core/src/engine/FFT.cu
+++ b/core/src/engine/FFT.cu
@@ -55,18 +55,6 @@ namespace Engine
         {
             cufftDestroy(this->cfg);
         }
-
-        void FFT_Plan::Clean()
-        {
-            this->cpx_ptr = field<FFT_cpx_type>();
-            this->real_ptr = field<FFT_real_type>();
-            Free_Configuration();
-        }
-
-        FFT_Plan::~FFT_Plan()
-        {
-            // kiss_fft_free(this->cfg);
-        }
     }
 }
 #endif

--- a/core/src/engine/Hamiltonian_Heisenberg.cpp
+++ b/core/src/engine/Hamiltonian_Heisenberg.cpp
@@ -39,7 +39,8 @@ namespace Engine
         exchange_pairs_in(exchange_pairs), exchange_magnitudes_in(exchange_magnitudes), exchange_shell_magnitudes(0),
         dmi_pairs_in(dmi_pairs), dmi_magnitudes_in(dmi_magnitudes), dmi_normals_in(dmi_normals), dmi_shell_magnitudes(0), dmi_shell_chirality(0),
         quadruplets(quadruplets), quadruplet_magnitudes(quadruplet_magnitudes),
-        ddi_method(ddi_method), ddi_n_periodic_images(ddi_n_periodic_images), ddi_cutoff_radius(ddi_radius)
+        ddi_method(ddi_method), ddi_n_periodic_images(ddi_n_periodic_images), ddi_cutoff_radius(ddi_radius), 
+        fft_plan_dipole(FFT::FFT_Plan()), fft_plan_reverse(FFT::FFT_Plan()), fft_plan_spins(FFT::FFT_Plan())
     {
         // Generate interaction pairs, constants etc.
         this->Update_Interactions();
@@ -63,7 +64,9 @@ namespace Engine
         exchange_pairs_in(0), exchange_magnitudes_in(0), exchange_shell_magnitudes(exchange_shell_magnitudes),
         dmi_pairs_in(0), dmi_magnitudes_in(0), dmi_normals_in(0), dmi_shell_magnitudes(dmi_shell_magnitudes), dmi_shell_chirality(dm_chirality),
         quadruplets(quadruplets), quadruplet_magnitudes(quadruplet_magnitudes),
-        ddi_method(ddi_method), ddi_n_periodic_images(ddi_n_periodic_images), ddi_cutoff_radius(ddi_radius)
+        ddi_method(ddi_method), ddi_n_periodic_images(ddi_n_periodic_images), ddi_cutoff_radius(ddi_radius),
+        fft_plan_dipole(FFT::FFT_Plan()), fft_plan_reverse(FFT::FFT_Plan()), fft_plan_spins(FFT::FFT_Plan())
+
     {
         // Generate interaction pairs, constants etc.
         this->Update_Interactions();
@@ -71,7 +74,6 @@ namespace Engine
 
     void Hamiltonian_Heisenberg::Update_Interactions()
     {
-        Clean_DDI();
         #if defined(SPIRIT_USE_OPENMP)
         // When parallelising (cuda or openmp), we need all neighbours per spin
         const bool use_redundant_neighbours = true;
@@ -159,9 +161,8 @@ namespace Engine
                 { this->ddi_pairs[i].i, this->ddi_pairs[i].j, this->ddi_pairs[i].translations },
                 this->ddi_magnitudes[i], this->ddi_normals[i]);
         }
-        // Dipole-dipole (FFT)
-        if(ddi_method == DDI_Method::FFT)
-            this->Prepare_DDI();
+        // Dipole-dipole
+        this->Prepare_DDI();
 
         // Update, which terms still contribute
         this->Update_Energy_Contributions();
@@ -1181,6 +1182,11 @@ namespace Engine
 
     void Hamiltonian_Heisenberg::Prepare_DDI()
     {
+        Clean_DDI();
+
+        if(ddi_method != DDI_Method::FFT)
+            return;
+
         n_cells_padded.resize(3);
         n_cells_padded[0] = (geometry->n_cells[0] > 1) ? 2 * geometry->n_cells[0] : 1;
         n_cells_padded[1] = (geometry->n_cells[1] > 1) ? 2 * geometry->n_cells[1] : 1;
@@ -1201,7 +1207,6 @@ namespace Engine
 
         inter_sublattice_lookup.resize(geometry->n_cell_atoms * geometry->n_cell_atoms);
 
-
         //we dont need to transform over length 1 dims
         std::vector<int> fft_dims;
         for(int i = 2; i >= 0; i--) //notice that reverse order is important!
@@ -1210,7 +1215,6 @@ namespace Engine
                 fft_dims.push_back(n_cells_padded[i]);
         }
         
-
         //Count how many distinct inter-lattice contributions we need to store
         n_inter_sublattice = 0;
         for(int i = 0; i < geometry->n_cell_atoms; i++)
@@ -1223,26 +1227,9 @@ namespace Engine
         }
 
         //Create fft plans.
-        fft_plan_dipole.dims     = fft_dims;
-        fft_plan_dipole.inverse  = false;
-        fft_plan_dipole.howmany  = 6 * n_inter_sublattice;
-        fft_plan_dipole.real_ptr = field<FFT::FFT_real_type>(n_inter_sublattice * 6 * sublattice_size);
-        fft_plan_dipole.cpx_ptr  = field<FFT::FFT_cpx_type>(n_inter_sublattice * 6 * sublattice_size);
-        fft_plan_dipole.Create_Configuration();
-
-        fft_plan_spins.dims     = fft_dims;
-        fft_plan_spins.inverse  = false;
-        fft_plan_spins.howmany  = 3 * geometry->n_cell_atoms;
-        fft_plan_spins.real_ptr = field<FFT::FFT_real_type>(3 * sublattice_size * geometry->n_cell_atoms);
-        fft_plan_spins.cpx_ptr  = field<FFT::FFT_cpx_type>(3 * sublattice_size * geometry->n_cell_atoms);
-        fft_plan_spins.Create_Configuration();
-
-        fft_plan_reverse.dims     = fft_dims;
-        fft_plan_reverse.inverse  = true;
-        fft_plan_reverse.howmany  = 3 * geometry->n_cell_atoms;
-        fft_plan_reverse.cpx_ptr  = field<FFT::FFT_cpx_type>(3 * sublattice_size * geometry->n_cell_atoms);
-        fft_plan_reverse.real_ptr = field<FFT::FFT_real_type>(3 * sublattice_size * geometry->n_cell_atoms);
-        fft_plan_reverse.Create_Configuration();
+        fft_plan_dipole = FFT::FFT_Plan(fft_dims, false, 6 * n_inter_sublattice, sublattice_size);
+        fft_plan_spins = FFT::FFT_Plan(fft_dims, false, 3 * geometry->n_cell_atoms, sublattice_size);
+        fft_plan_reverse = FFT::FFT_Plan(fft_dims, true, 3 * geometry->n_cell_atoms, sublattice_size);
 
         #ifdef SPIRIT_USE_FFTW
             field<int*> temp_s = {&spin_stride.comp, &spin_stride.basis, &spin_stride.a, &spin_stride.b, &spin_stride.c};
@@ -1272,16 +1259,17 @@ namespace Engine
 
         if(save_dipole_matrices)
             dipole_matrices = field<Matrix3>(n_inter_sublattice * geometry->n_cells_total);
+
         FFT_Dipole_Matrices(img_a, img_b, img_c);
-        fft_plan_dipole.real_ptr = field<FFT::FFT_real_type>();
-        fft_plan_dipole.Free_Configuration();
+        // fft_plan_dipole.real_ptr = field<FFT::FFT_real_type>();
+        // fft_plan_dipole.Free_Configuration();
     }
 
     void Hamiltonian_Heisenberg::Clean_DDI()
     {
-        fft_plan_spins.Clean();
-        fft_plan_dipole.Clean();
-        fft_plan_reverse.Clean();
+        fft_plan_spins   = FFT::FFT_Plan();
+        fft_plan_dipole  = FFT::FFT_Plan();
+        fft_plan_reverse = FFT::FFT_Plan();
     }
 
     // Hamiltonian name as string

--- a/core/src/engine/Hamiltonian_Heisenberg.cpp
+++ b/core/src/engine/Hamiltonian_Heisenberg.cpp
@@ -1227,8 +1227,8 @@ namespace Engine
         }
 
         //Create fft plans.
-        fft_plan_dipole = FFT::FFT_Plan(fft_dims, false, 6 * n_inter_sublattice, sublattice_size);
-        fft_plan_spins = FFT::FFT_Plan(fft_dims, false, 3 * geometry->n_cell_atoms, sublattice_size);
+        fft_plan_dipole  = FFT::FFT_Plan(fft_dims, false, 6 * n_inter_sublattice, sublattice_size);
+        fft_plan_spins   = FFT::FFT_Plan(fft_dims, false, 3 * geometry->n_cell_atoms, sublattice_size);
         fft_plan_reverse = FFT::FFT_Plan(fft_dims, true, 3 * geometry->n_cell_atoms, sublattice_size);
 
         #ifdef SPIRIT_USE_FFTW

--- a/core/src/engine/Vectormath.cu
+++ b/core/src/engine/Vectormath.cu
@@ -795,7 +795,7 @@ namespace Engine
             CU_CHECK_AND_SYNC();
         }
 
-        __global__ void cu_scale(Vector3 *vf1, scalar * sf, bool inverse, size_t N)
+        __global__ void cu_scale(Vector3 *vf1, const scalar * sf, bool inverse, size_t N)
         {
             int idx = blockIdx.x * blockDim.x + threadIdx.x;
             if(idx < N)


### PR DESCRIPTION
This pull request addresses issue #468.
FFT_Plan has been reworked and 
 - a proper constructor / copy constructor
 - move and copy assignment operators
 - a destructor

have been added. This should resolve the issues ocurring when the fft_plans get copied from one image to another.
Additionally fft_plan_dipole() is now automatically freed because it is just temporarily allocated in Hamiltonian_Heisenberg::Prepare_DDI().