### PR TITLE
Fix wrong calculation of basis spin positions

### DIFF
--- a/core/src/engine/Hamiltonian_Heisenberg.cpp
+++ b/core/src/engine/Hamiltonian_Heisenberg.cpp
@@ -1072,14 +1072,14 @@ namespace Engine
 
     void Hamiltonian_Heisenberg::FFT_Dipole_Matrices(FFT::FFT_Plan & fft_plan_dipole, int img_a, int img_b, int img_c)
     {
-        //prefactor of ddi interaction
+        // Prefactor of ddi interaction
         scalar mult = C::mu_0 * C::mu_B * C::mu_B / ( 4*C::Pi * 1e-30 );
 
-        //size of original geometry
+        // Size of original geometry
         int Na = geometry->n_cells[0];
         int Nb = geometry->n_cells[1];
         int Nc = geometry->n_cells[2];
-        //bravais vectors
+        // Bravais vectors
         Vector3 ta = geometry->bravais_vectors[0];
         Vector3 tb = geometry->bravais_vectors[1];
         Vector3 tc = geometry->bravais_vectors[2];
@@ -1099,7 +1099,7 @@ namespace Engine
                 b_inter++;
                 inter_sublattice_lookup[i_b1 + i_b2 * geometry->n_cell_atoms] = b_inter;
 
-                //iterate over the padded system
+                // Iterate over the padded system
                 #pragma omp parallel for collapse(3)
                 for( int c = 0; c < n_cells_padded[2]; ++c )
                 {
@@ -1112,17 +1112,18 @@ namespace Engine
                             int c_idx = c < Nc ? c : c - n_cells_padded[2];
                             scalar Dxx = 0, Dxy = 0, Dxz = 0, Dyy = 0, Dyz = 0, Dzz = 0;
                             Vector3 diff;
-                            //iterate over periodic images
-
+                            // Iterate over periodic images
                             for( int a_pb = - img_a; a_pb <= img_a; a_pb++ )
                             {
                                 for( int b_pb = - img_b; b_pb <= img_b; b_pb++ )
                                 {
                                     for( int c_pb = -img_c; c_pb <= img_c; c_pb++ )
                                     {
-                                        diff =    (a_idx + a_pb * Na + geometry->cell_atoms[i_b1][0] - geometry->cell_atoms[i_b2][0]) * ta
-                                                + (b_idx + b_pb * Nb + geometry->cell_atoms[i_b1][1] - geometry->cell_atoms[i_b2][1]) * tb
-                                                + (c_idx + c_pb * Nc + geometry->cell_atoms[i_b1][2] - geometry->cell_atoms[i_b2][2]) * tc;
+                                        diff =    (a_idx + a_pb * Na) * ta
+                                                + (b_idx + b_pb * Nb) * tb
+                                                + (c_idx + c_pb * Nc) * tc
+                                                + geometry->cell_atoms[i_b1]
+                                                - geometry->cell_atoms[i_b2];
                                         if( diff.norm() > 1e-10 )
                                         {
                                             auto d = diff.norm();
@@ -1148,7 +1149,7 @@ namespace Engine
                             fft_dipole_inputs[idx + 4 * dipole_stride.comp] = Dyz;
                             fft_dipole_inputs[idx + 5 * dipole_stride.comp] = Dzz;
 
-                            //We explicitly ignore the different strides etc. here
+                            // We explicitly ignore the different strides etc. here
                             if( save_dipole_matrices && a < Na && b < Nb && c < Nc )
                             {
                                 dipole_matrices[b_inter + n_inter_sublattice * (a + Na * (b + Nb * c))] <<  Dxx, Dxy, Dxz,

--- a/core/src/engine/Hamiltonian_Heisenberg.cpp
+++ b/core/src/engine/Hamiltonian_Heisenberg.cpp
@@ -373,9 +373,7 @@ namespace Engine
                             if( jspin >= 0 )
                             {
                                 Energy[ispin] -= 0.5 * mu_s[ispin] * mu_s[jspin] * mult / std::pow(ddi_magnitudes[i_pair], 3.0) *
-                                    (3 * spins[ispin].dot(ddi_normals[i_pair]) * spins[ispin].dot(ddi_normals[i_pair]) - spins[ispin].dot(spins[ispin]));
-                                Energy[jspin] -= 0.5 * mu_s[ispin] * mu_s[jspin] * mult / std::pow(ddi_magnitudes[i_pair], 3.0) *
-                                    (3 * spins[ispin].dot(ddi_normals[i_pair]) * spins[ispin].dot(ddi_normals[i_pair]) - spins[ispin].dot(spins[ispin]));
+                                    (3 * spins[ispin].dot(ddi_normals[i_pair]) * spins[jspin].dot(ddi_normals[i_pair]) - spins[ispin].dot(spins[jspin]));
                             }
                         }
                     }
@@ -705,7 +703,6 @@ namespace Engine
                             if( jspin >= 0 )
                             {
                                 gradient[ispin] -= mu_s[jspin] * skalar_contrib * (3 * ddi_normals[i_pair] * spins[jspin].dot(ddi_normals[i_pair]) - spins[jspin]);
-                                gradient[jspin] -= mu_s[ispin] * skalar_contrib * (3 * ddi_normals[i_pair] * spins[ispin].dot(ddi_normals[i_pair]) - spins[ispin]);
                             }
                         }
                     }

--- a/core/src/engine/Hamiltonian_Heisenberg.cu
+++ b/core/src/engine/Hamiltonian_Heisenberg.cu
@@ -1073,11 +1073,12 @@ namespace Engine
                             {
                                 for(int c_pb = -img[2]; c_pb <= img[2]; c_pb++)
                                 {
-
-                                    diff =    (a_idx + a_pb * n_cells[0] + cell_atoms[i_b1][0] - cell_atoms[i_b2][0]) * bravais_vectors[0]
-                                            + (b_idx + b_pb * n_cells[1] + cell_atoms[i_b1][1] - cell_atoms[i_b2][1]) * bravais_vectors[1]
-                                            + (c_idx + c_pb * n_cells[2] + cell_atoms[i_b1][2] - cell_atoms[i_b2][2]) * bravais_vectors[2];
-
+                                    diff =    (a_idx + a_pb * n_cells[0]) * bravais_vectors[0]
+                                            + (b_idx + b_pb * n_cells[1]) * bravais_vectors[1]
+                                            + (c_idx + c_pb * n_cells[2]) * bravais_vectors[2]
+                                            + cell_atoms[i_b1]
+                                            - cell_atoms[i_b2];
+                                            
                                     if(diff.norm() > 1e-10)
                                     {
                                         auto d = diff.norm();

--- a/core/src/engine/Vectormath.cpp
+++ b/core/src/engine/Vectormath.cpp
@@ -99,11 +99,8 @@ namespace Engine
             std::vector<Data::vector2_t> basis_cell_points(geometry.n_cell_atoms + 3);
             for(int i = 0; i < geometry.n_cell_atoms; i++)
             {
-                for(int j=0; j<2; j++)
-                {
-                    basis_cell_points[i].x = double(geometry.cell_atoms[i][j] * geometry.bravais_vectors[j][0]);
-                    basis_cell_points[i].y = double(geometry.cell_atoms[i][j] * geometry.bravais_vectors[j][1]);
-                }
+                basis_cell_points[i].x = double(geometry.cell_atoms[i][0]);
+                basis_cell_points[i].y = double(geometry.cell_atoms[i][1]);
             }
 
             Vector3 basis_offset = geometry.cell_atoms[0][0] * geometry.bravais_vectors[0] + geometry.cell_atoms[0][1] * geometry.bravais_vectors[1];

--- a/core/src/engine/Vectormath.cu
+++ b/core/src/engine/Vectormath.cu
@@ -297,11 +297,8 @@ namespace Engine
             std::vector<Data::vector2_t> basis_cell_points(geometry.n_cell_atoms + 3);
             for(int i = 0; i < geometry.n_cell_atoms; i++)
             {
-                for(int j=0; j<2; j++)
-                {
-                    basis_cell_points[i].x = double(geometry.cell_atoms[i][j] * geometry.bravais_vectors[j][0]);
-                    basis_cell_points[i].y = double(geometry.cell_atoms[i][j] * geometry.bravais_vectors[j][1]);
-                }
+                basis_cell_points[i].x = double(geometry.cell_atoms[i][0]);
+                basis_cell_points[i].y = double(geometry.cell_atoms[i][1]);
             }
 
             Vector3 basis_offset = geometry.cell_atoms[0][0] * geometry.bravais_vectors[0] + geometry.cell_atoms[0][1] * geometry.bravais_vectors[1];

--- a/core/test/input/physics_ddi.cfg
+++ b/core/test/input/physics_ddi.cfg
@@ -65,7 +65,7 @@ n_interaction_pairs 0
 lattice_constant 1.0
 
 ### The bravais lattice type
-bravais_lattice sc
+bravais_lattice hex2d
 
 ### Number of basis cells along principal
 ### directions (a b c)


### PR DESCRIPTION
In `Hamiltonian_Heisenberg::FFT_Dipole_Matrices( ... )` and `Vectormath::TopologicalCharge( ... )` the positions of basis spins inside the basis cell was done incorrectly, leading to errors for non-sc lattices with additional basis atoms. This PR fixes that. 
Also the ddi-unit test has been made more general so it can catch errors like this in the future.
