### PR TITLE
repair Image_Write_Energy_per_Spin and include it into the python int…

### DIFF
--- a/core/python/spirit/io.py
+++ b/core/python/spirit/io.py
@@ -203,3 +203,23 @@ def eigenmodes_write(p_state, filename, fileformat=FILEFORMAT_OVF_TEXT, comment=
     _Eigenmodes_Write(ctypes.c_void_p(p_state), ctypes.c_char_p(filename.encode('utf-8')),
                       ctypes.c_int(fileformat), ctypes.c_char_p(comment.encode('utf-8')),
                       ctypes.c_int(idx_image), ctypes.c_int(idx_chain))
+
+
+_Image_Write_Energy_per_Spin             = _spirit.IO_Image_Write_Energy_per_Spin
+_Image_Write_Energy_per_Spin.argtypes    = [ctypes.c_void_p, ctypes.c_char_p, ctypes.c_int,
+                                 ctypes.c_int, ctypes.c_int]
+_Eigenmodes_Write.restype     = None
+def Image_Write_Energy_per_Spin(p_state, filename, fileformat=FILEFORMAT_OVF_TEXT, idx_image=-1, idx_chain=-1):
+    """Write the energies per spin to a file.
+
+    Arguments:
+
+    - `p_state`: state pointer
+    - `filename`: the name of the file to append to
+
+    Keyword arguments
+
+    - `fileformat`: the format in which to write the data (default: OVF text)
+    """
+    _Image_Write_Energy_per_Spin(ctypes.c_void_p(p_state), ctypes.c_char_p(filename.encode('utf-8')),
+                                 ctypes.c_int(fileformat), ctypes.c_int(idx_image), ctypes.c_int(idx_chain))

--- a/core/src/Spirit/IO.cpp
+++ b/core/src/Spirit/IO.cpp
@@ -852,7 +852,8 @@ try
     std::vector<std::pair<std::string, scalarfield>> contributions_spins(0);
     system.UpdateEnergy();
     system.hamiltonian->Energy_Contributions_per_Spin(spins, contributions_spins);
-    int datasize = (1+contributions_spins.size())*system.nos;
+    int dataperspin = 1+contributions_spins.size();
+    int datasize = dataperspin*system.nos;
     scalarfield data(datasize, 0);
     for( int ispin=0; ispin<system.nos; ++ispin )
     {
@@ -861,10 +862,10 @@ try
         for( auto& contribution : contributions_spins )
         {
             E_spin += contribution.second[ispin];
-            data[ispin+j] = contribution.second[ispin];
+            data[ispin*dataperspin+j] = contribution.second[ispin];
             ++j;
         }
-        data[ispin] = E_spin;
+        data[ispin*dataperspin] = E_spin;
     }
 
     try

--- a/core/src/engine/Hamiltonian_Heisenberg.cu
+++ b/core/src/engine/Hamiltonian_Heisenberg.cu
@@ -215,6 +215,10 @@ namespace Engine
 
     void Hamiltonian_Heisenberg::Energy_Contributions_per_Spin(const vectorfield & spins, std::vector<std::pair<std::string, scalarfield>> & contributions)
     {
+        if( contributions.size() != this->energy_contributions_per_spin.size() )
+        {
+            contributions = this->energy_contributions_per_spin;
+        }
         int nos = spins.size();
         for (auto& pair : contributions)
         {


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read the [README](https://github.com/spirit-code/spirit/blob/develop/README.md)
- [x] I have read the [CONTRIBUTING](https://github.com/spirit-code/spirit/blob/develop/docs/CONTRIBUTING.md) document

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have branched from the `develop` branch
- [x] My commits are in nice logical chunks
- [x] My contribution is fully baked and is ready to be merged as is **or**
      I have cleanly laid out what this pull request should achieve in the end

------------------------------

### Description
<!--
    Describe briefly what your pull request proposes to implement.
    Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to achieve.
    You can also use the `fixes #1234` syntax to refer to specific issues.
-->
This repairs the previously broken "Save Energy per Spin" function and adds a python interface to call it.
