### PR TITLE
Core: variadic templates for backend.

### DIFF
--- a/core/include/engine/Backend_par.hpp
+++ b/core/include/engine/Backend_par.hpp
@@ -4,6 +4,8 @@
 
 #include <engine/Vectormath_Defines.hpp>
 
+#include <tuple>
+
 #ifdef SPIRIT_USE_CUDA
     #include <cub/cub.cuh>
     #define SPIRIT_LAMBDA __device__
@@ -20,6 +22,7 @@ namespace par
 
 #ifdef SPIRIT_USE_CUDA
 
+    // f(i) for all i
     template<typename F>
     __global__
     void cu_apply(int N, F f)
@@ -28,8 +31,7 @@ namespace par
         if(idx < N)
             f(idx);
     }
-
-    // vf1[i] = f( vf2[i] )
+    // f(i) for all i
     template<typename F>
     void apply(int N, F f)
     {
@@ -37,20 +39,37 @@ namespace par
         CU_CHECK_AND_SYNC();
     }
 
-    template<typename F>
-    scalar reduce(int N, const F f)
+    // vf_to[i] = f(args[i]...) for all i
+    template<typename A, typename Lambda, typename... args>
+    __global__
+    void cu_assign_lambda(int N, A * vf_to, Lambda lambda, const args *... arg_fields)
     {
-        static scalarfield sf(N, 0);
-        // Vectormath::fill(sf, 0);
+        int idx = blockIdx.x * blockDim.x + threadIdx.x;
+        if(idx < N)
+            vf_to[idx] = lambda(arg_fields[idx]...);
+    }
+    // field[i] = f(args[i]...) for all i
+    template<typename A, typename Lambda, typename... args>
+    void assign(field<A> & vf_to, Lambda lambda, const field<args> &... vf_args)
+    {
+        int N = vf_to.size();
+        cu_assign_lambda<<<(N+1023)/1024, 1024>>>(N, vf_to.data(), lambda, vf_args.data()...);
+        CU_CHECK_AND_SYNC();
+    }
 
+    // result = sum_i f(args[i]...)
+    template<typename Lambda, typename... args> inline
+    scalar pointer_reduce(int N, const Lambda & lambda, const args *... vf_args)
+    {
+        // TODO: remove the reliance on a temporary scalar field (maybe thrust::dot with generalized operations)
+        static scalarfield sf(N, 0);
         if(sf.size() != N)
             sf.resize(N);
 
         auto s  = sf.data();
-        apply( N, [f, s] SPIRIT_LAMBDA (int idx) { s[idx] = f(idx); } );
+        apply( N, [s, vf_args...] SPIRIT_LAMBDA (int idx) { s[idx] = f(vf_args[idx]...); } );
 
         static scalarfield ret(1, 0);
-
         // Determine temporary storage size and allocate
         void * d_temp_storage = NULL;
         size_t temp_storage_bytes = 0;
@@ -62,155 +81,69 @@ namespace par
         cudaFree(d_temp_storage);
         return ret[0];
     }
-
-    template<typename A, typename F>
-    scalar reduce(const field<A> & vf1, const F f)
+    // result = sum_i f(args[i]...)
+    template<typename Lambda, typename... args> inline
+    scalar reduce(const Lambda & lambda, const field<args> &... vf_args)
     {
-        // TODO: remove the reliance on a temporary scalar field (maybe thrust::dot with generalized operations)
-        // We also use this workaround for a single field as argument, because cub does not support non-commutative reduction operations
-
-        int n = vf1.size();
-        static scalarfield sf(n, 0);
-        // Vectormath::fill(sf, 0);
-
-        if(sf.size() != vf1.size())
-            sf.resize(vf1.size());
-
-        auto s  = sf.data();
-        auto v1 = vf1.data();
-        apply( n, [f, s, v1] SPIRIT_LAMBDA (int idx) { s[idx] = f(v1[idx]); } );
-
-        static scalarfield ret(1, 0);
-        // Vectormath::fill(ret, 0);
-
-        // Determine temporary storage size and allocate
-        void * d_temp_storage = NULL;
-        size_t temp_storage_bytes = 0;
-        cub::DeviceReduce::Sum(d_temp_storage, temp_storage_bytes, sf.data(), ret.data(), sf.size());
-        cudaMalloc(&d_temp_storage, temp_storage_bytes);
-        // Reduction
-        cub::DeviceReduce::Sum(d_temp_storage, temp_storage_bytes, sf.data(), ret.data(), sf.size());
-        CU_CHECK_AND_SYNC();
-        cudaFree(d_temp_storage);
-        return ret[0];
+        auto N = std::get<0>(std::tuple<const field<args> &...>(vf_args...)).size();
+        // We take this umweg so that `.data()` won't be called for every element of each field
+        return pointer_reduce(N, lambda, vf_args.data()...);
     }
 
-    template<typename A, typename B, typename F>
-    scalar reduce(const field<A> & vf1, const field<B> & vf2, const F f)
-    {
-        // TODO: remove the reliance on a temporary scalar field (maybe thrust::dot with generalized operations)
-        int n = vf1.size();
-        static scalarfield sf(n, 0);
-        // Vectormath::fill(sf, 0);
-
-        if(sf.size() != vf1.size())
-            sf.resize(vf1.size());
-
-        auto s  = sf.data();
-        auto v1 = vf1.data();
-        auto v2 = vf2.data();
-        apply( n, [f, s, v1, v2] SPIRIT_LAMBDA (int idx) { s[idx] = f(v1[idx], v2[idx]); } );
-
-        static scalarfield ret(1, 0);
-        // Vectormath::fill(ret, 0);
-        // Determine temporary storage size and allocate
-        void * d_temp_storage = NULL;
-        size_t temp_storage_bytes = 0;
-        cub::DeviceReduce::Sum(d_temp_storage, temp_storage_bytes, sf.data(), ret.data(), sf.size());
-        cudaMalloc(&d_temp_storage, temp_storage_bytes);
-        // Reduction
-        cub::DeviceReduce::Sum(d_temp_storage, temp_storage_bytes, sf.data(), ret.data(), sf.size());
-        CU_CHECK_AND_SYNC();
-        cudaFree(d_temp_storage);
-        return ret[0];
-    }
-
-
-    // vf1[i] = f( vf2[i] )
-    template<typename A, typename B, typename F>
-    __global__
-    void cu_set_lambda(A * vf1, const B * vf2, F f, int N)
-    {
-        int idx = blockIdx.x * blockDim.x + threadIdx.x;
-        if(idx < N)
-        {
-            vf1[idx] = f(vf2[idx]);
-        }
-    }
-
-    // vf1[i] = f( vf2[i] )
-    template<typename A, typename B, typename F>
-    void set(field<A> & vf1, const field<B> & vf2, F f)
-    {
-        int N = vf1.size();
-        cu_set_lambda<<<(N+1023)/1024, 1024>>>(vf1.data(), vf2.data(), f, N);
-        CU_CHECK_AND_SYNC();
-    }
-    
 #else
 
-    template<typename F>
-    scalar reduce(int N, const F f)
-    {
-        scalar res = 0;
-        #pragma omp parallel for reduction(+:res)
-        for(unsigned int idx = 0; idx < N; ++idx)
-        {
-            res += f(idx);
-        }
-        return res;
-    }
-
-    template<typename A, typename F>
-    scalar reduce(const field<A> & vf1, const F f)
-    {
-        scalar res=0;
-        #pragma omp parallel for reduction(+:res)
-        for(unsigned int idx = 0; idx < vf1.size(); ++idx)
-        {
-            res += f(vf1[idx]);
-        }
-        return res;
-    }
-
-    // result = sum_i  f( vf1[i], vf2[i] )
-    template<typename A, typename B, typename F>
-    scalar reduce(const field<A> & vf1, const field<B> & vf2, const F & f)
-    {
-        scalar res=0;
-        #pragma omp parallel for reduction(+:res)
-        for(unsigned int idx = 0; idx < vf1.size(); ++idx)
-        {
-            res += f(vf1[idx], vf2[idx]);
-        }
-        return res;
-    }
-
-    // vf1[i] = f( vf2[i] )
-    template<typename A, typename B, typename F>
-    void set(field<A> & vf1, const field<B> & vf2, const F & f)
-    {
-        #pragma omp parallel for
-        for(unsigned int idx = 0; idx < vf1.size(); ++idx)
-        {
-            vf1[idx] = f(vf2[idx]);
-        }
-    }
-
-    // f( vf1[idx], idx ) for all i
+    // f(i) for all i
     template<typename F>
     void apply(int N, const F & f)
     {
         #pragma omp parallel for
         for(unsigned int idx = 0; idx < N; ++idx)
-        {
             f(idx);
-        }
+    }
+
+    // vf_to[i] = f(args[i]...) for all i
+    template<typename A, typename Lambda, typename... args> inline
+    void pointer_assign(int N, A * vf_to, Lambda lambda, const args *... vf_args)
+    {
+        #pragma omp parallel for
+        for(unsigned int idx = 0; idx < N; ++idx)
+            vf_to[idx] = lambda(vf_args[idx]...);
+    }
+    // vf_to[i] = f(args[i]...) for all i
+    template<typename A, typename Lambda, typename... args> inline
+    void assign(field<A> & vf_to, Lambda lambda, const field<args> &... vf_args)
+    {
+        auto N = vf_to.size();
+        // We take this umweg so that `.data()` won't be called for every element of each field
+        pointer_assign(N, vf_to.data(), lambda, vf_args.data()...);
     }
 
 
+    // result = sum_i f(args[i]...)
+    template<typename Lambda, typename... args> inline
+    scalar pointer_reduce(int N, const Lambda & lambda, const args *... vf_args)
+    {
+        scalar res = 0;
+
+        #pragma omp parallel for reduction(+:res)
+        for(unsigned int idx = 0; idx < N; ++idx)
+            res += lambda(vf_args[idx]...);
+
+        return res;
+    }
+    // result = sum_i f(args[i]...)
+    template<typename Lambda, typename... args> inline
+    scalar reduce(const Lambda & lambda, const field<args> &... vf_args)
+    {
+        auto N = std::get<0>(std::tuple<const field<args> &...>(vf_args...)).size();
+        // We take this umweg so that `.data()` won't be called for every element of each field
+        return pointer_reduce(N, lambda, vf_args.data()...);
+    }
+
 #endif
+
 } // namespace par
 } // namespace Backend
 } // namespace Engine
+
 #endif

--- a/core/include/engine/Backend_par.hpp
+++ b/core/include/engine/Backend_par.hpp
@@ -62,7 +62,6 @@ namespace par
     scalar reduce(int N, const Lambda f)
     {
         static scalarfield sf(N, 0);
-        // Vectormath::fill(sf, 0);
 
         if(sf.size() != N)
             sf.resize(N);
@@ -92,7 +91,6 @@ namespace par
 
         int n = vf1.size();
         static scalarfield sf(n, 0);
-        // Vectormath::fill(sf, 0);
 
         if(sf.size() != vf1.size())
             sf.resize(vf1.size());
@@ -102,7 +100,6 @@ namespace par
         apply( n, [f, s, v1] SPIRIT_LAMBDA (int idx) { s[idx] = f(v1[idx]); } );
 
         static scalarfield ret(1, 0);
-        // Vectormath::fill(ret, 0);
 
         // Determine temporary storage size and allocate
         void * d_temp_storage = NULL;
@@ -122,7 +119,6 @@ namespace par
         // TODO: remove the reliance on a temporary scalar field (maybe thrust::dot with generalized operations)
         int n = vf1.size();
         static scalarfield sf(n, 0);
-        // Vectormath::fill(sf, 0);
 
         if(sf.size() != vf1.size())
             sf.resize(vf1.size());
@@ -133,7 +129,6 @@ namespace par
         apply( n, [f, s, v1, v2] SPIRIT_LAMBDA (int idx) { s[idx] = f(v1[idx], v2[idx]); } );
 
         static scalarfield ret(1, 0);
-        // Vectormath::fill(ret, 0);
         // Determine temporary storage size and allocate
         void * d_temp_storage = NULL;
         size_t temp_storage_bytes = 0;

--- a/core/include/engine/Hamiltonian_Heisenberg.hpp
+++ b/core/include/engine/Hamiltonian_Heisenberg.hpp
@@ -152,11 +152,12 @@ namespace Engine
         // Calculate the Quadruplet energy
         void E_Quadruplet(const vectorfield & spins, scalarfield & Energy);
 
-        private:
-        int idx_zeeman, idx_anisotropy, idx_exchange, idx_dmi, idx_ddi, idx_quadruplet;
         void Gradient_DDI_Cutoff(const vectorfield& spins, vectorfield & gradient);
         void Gradient_DDI_Direct(const vectorfield& spins, vectorfield & gradient);
         void Gradient_DDI_FFT(const vectorfield& spins, vectorfield & gradient);
+
+    private:
+        int idx_zeeman, idx_anisotropy, idx_exchange, idx_dmi, idx_ddi, idx_quadruplet;
         void E_DDI_Direct(const vectorfield& spins, scalarfield & Energy);
         void E_DDI_Cutoff(const vectorfield& spins, scalarfield & Energy);
         void E_DDI_FFT(const vectorfield& spins, scalarfield & Energy);

--- a/core/include/engine/Solver_Heun.hpp
+++ b/core/include/engine/Solver_Heun.hpp
@@ -65,7 +65,7 @@ void Method_Solver<Solver::Heun>::Iteration ()
         // Second step - Corrector
         Backend::par::apply( nos, [conf, conf_predictor, f_virtual, f_virtual_predictor] SPIRIT_LAMBDA (int idx) {
             conf[idx] = (
-                conf[idx] + 0.5*( conf[idx] - 0.5*conf[idx].cross(f_virtual[idx]) - conf_predictor[idx].cross(f_virtual_predictor[idx]) )
+                conf[idx] - 0.5 * ( conf[idx].cross( f_virtual[idx] ) + conf_predictor[idx].cross(f_virtual_predictor[idx]) )
             ).normalized();
         } );
     }

--- a/core/include/engine/Solver_Kernels.hpp
+++ b/core/include/engine/Solver_Kernels.hpp
@@ -38,8 +38,8 @@ namespace Solver_Kernels
                              std::vector<field<field<Vec>>> & delta_a, std::vector<field<field<Vec>>> & delta_grad, const std::vector<field<Vec>> & grad, std::vector<field<Vec>> & grad_pr,
                              const int num_mem, const scalar maxmove) {
         // std::cerr << "lbfgs searchdir \n";
-        static auto dot = [] SPIRIT_LAMBDA (const Vec & v1, const Vec &v2) {return v1.dot(v2);};
-        static auto set = [] SPIRIT_LAMBDA (const Vec & x) {return x;};
+        static auto set = [] SPIRIT_LAMBDA (const Vec & x) -> Vec {return x;};
+        static auto dot = [] SPIRIT_LAMBDA (const Vec & v1, const Vec &v2) -> scalar {return v1.dot(v2);};
 
         scalar epsilon = sizeof(scalar) == sizeof(float) ? 1e-30 : 1e-300;
 
@@ -50,11 +50,15 @@ namespace Solver_Kernels
 
         if (local_iter == 0) // gradient descent
         {
-            for(int img=0; img<noi; img++) {
-                Backend::par::set(grad_pr[img], grad[img], set);
-                auto & dir = searchdir[img];
-                auto & g_cur = grad[img];
-                Backend::par::set(dir, g_cur, [] SPIRIT_LAMBDA (const Vec & x){return -x;});
+            for(int img=0; img<noi; img++)
+            {
+                auto g_ptr = grad[img].data();
+                auto g_pr_ptr = grad_pr[img].data();
+                auto dir_ptr = searchdir[img].data();
+                Backend::par::apply(nos, [g_ptr, g_pr_ptr, dir_ptr] SPIRIT_LAMBDA (int idx){
+                    g_pr_ptr[idx] = g_ptr[idx];
+                    dir_ptr[idx] = -g_ptr[idx];
+                });
                 auto & da = delta_a[img];
                 auto & dg = delta_grad[img];
                 for (int i = 0; i < num_mem; i++)
@@ -68,7 +72,9 @@ namespace Solver_Kernels
                     });
                 }
             }
-        } else {
+        }
+        else
+        {
             for (int img=0; img<noi; img++)
             {
                 auto da = delta_a[img][m_index].data();
@@ -84,7 +90,7 @@ namespace Solver_Kernels
 
             scalar rinv_temp = 0;
             for (int img=0; img<noi; img++)
-                rinv_temp += Backend::par::reduce(delta_grad[img][m_index], delta_a[img][m_index], dot);
+                rinv_temp += Backend::par::reduce(dot, delta_grad[img][m_index], delta_a[img][m_index]);
 
             if (rinv_temp > epsilon)
                 rho[m_index] = 1.0 / rinv_temp;
@@ -96,14 +102,14 @@ namespace Solver_Kernels
             }
 
             for (int img=0; img<noi; img++)
-                Backend::par::set(q_vec[img], grad[img], set);
+                Backend::par::assign(q_vec[img], set, grad[img]);
 
             for (int k = num_mem - 1; k > -1; k--)
             {
                 c_ind = (k + m_index + 1) % num_mem;
                 scalar temp=0;
                 for (int img=0; img<noi; img++)
-                    temp += Backend::par::reduce(delta_a[img][c_ind], q_vec[img], dot);
+                    temp += Backend::par::reduce(dot, delta_a[img][c_ind], q_vec[img]);
 
                 alpha[c_ind] = rho[c_ind] * temp;
                 for (int img=0; img<noi; img++)
@@ -119,7 +125,7 @@ namespace Solver_Kernels
 
             scalar dy2=0;
             for (int img=0; img<noi; img++)
-                dy2 += Backend::par::reduce(delta_grad[img][m_index], delta_grad[img][m_index], dot);
+                dy2 += Backend::par::reduce(dot, delta_grad[img][m_index], delta_grad[img][m_index]);
 
             for (int img=0; img<noi; img++)
             {
@@ -129,9 +135,9 @@ namespace Solver_Kernels
                     inv_rhody2 = 1.0 / rhody2;
                 else
                     inv_rhody2 = 1.0/(epsilon);
-                Backend::par::set(searchdir[img], q_vec[img], [inv_rhody2] SPIRIT_LAMBDA (const Vec & q){
+                Backend::par::assign(searchdir[img], [inv_rhody2] SPIRIT_LAMBDA (const Vec & q){
                     return inv_rhody2 * q;
-                } );
+                }, q_vec[img] );
             }
 
             for (int k = 0; k < num_mem; k++)
@@ -143,7 +149,7 @@ namespace Solver_Kernels
 
                 scalar rhopdg = 0;
                 for(int img=0; img<noi; img++)
-                    rhopdg += Backend::par::reduce(delta_grad[img][c_ind], searchdir[img], dot);
+                    rhopdg += Backend::par::reduce(dot, delta_grad[img][c_ind], searchdir[img]);
 
                 rhopdg *= rho[c_ind];
 

--- a/core/include/engine/Solver_Kernels.hpp
+++ b/core/include/engine/Solver_Kernels.hpp
@@ -90,7 +90,7 @@ namespace Solver_Kernels
 
             scalar rinv_temp = 0;
             for (int img=0; img<noi; img++)
-                rinv_temp += Backend::par::reduce(dot, delta_grad[img][m_index], delta_a[img][m_index]);
+                rinv_temp += Backend::par::reduce(nos, dot, delta_grad[img][m_index], delta_a[img][m_index]);
 
             if (rinv_temp > epsilon)
                 rho[m_index] = 1.0 / rinv_temp;
@@ -109,7 +109,7 @@ namespace Solver_Kernels
                 c_ind = (k + m_index + 1) % num_mem;
                 scalar temp=0;
                 for (int img=0; img<noi; img++)
-                    temp += Backend::par::reduce(dot, delta_a[img][c_ind], q_vec[img]);
+                    temp += Backend::par::reduce(nos, dot, delta_a[img][c_ind], q_vec[img]);
 
                 alpha[c_ind] = rho[c_ind] * temp;
                 for (int img=0; img<noi; img++)
@@ -125,7 +125,7 @@ namespace Solver_Kernels
 
             scalar dy2=0;
             for (int img=0; img<noi; img++)
-                dy2 += Backend::par::reduce(dot, delta_grad[img][m_index], delta_grad[img][m_index]);
+                dy2 += Backend::par::reduce(nos, dot, delta_grad[img][m_index], delta_grad[img][m_index]);
 
             for (int img=0; img<noi; img++)
             {
@@ -149,7 +149,7 @@ namespace Solver_Kernels
 
                 scalar rhopdg = 0;
                 for(int img=0; img<noi; img++)
-                    rhopdg += Backend::par::reduce(dot, delta_grad[img][c_ind], searchdir[img]);
+                    rhopdg += Backend::par::reduce(nos, dot, delta_grad[img][c_ind], searchdir[img]);
 
                 rhopdg *= rho[c_ind];
 

--- a/core/include/engine/Solver_LBFGS_Atlas.hpp
+++ b/core/include/engine/Solver_LBFGS_Atlas.hpp
@@ -80,7 +80,9 @@ void Method_Solver<Solver::LBFGS_Atlas>::Iteration()
     // Scale by averaging
     for(int img=0; img<noi; img++)
     {
-        a_norm_rms = std::max(a_norm_rms, scalar( sqrt( Backend::par::reduce(this->atlas_directions[img], [] SPIRIT_LAMBDA (const Vector2 & v){ return v.squaredNorm(); }) / nos )));
+        a_norm_rms = std::max( a_norm_rms, scalar( sqrt(
+            Backend::par::reduce([] SPIRIT_LAMBDA (const Vector2 & v){ return v.squaredNorm(); }, this->atlas_directions[img]) / nos
+        )));
     }
     scalar scaling = (a_norm_rms > maxmove) ? maxmove/a_norm_rms : 1.0;
 

--- a/core/include/engine/Solver_LBFGS_Atlas.hpp
+++ b/core/include/engine/Solver_LBFGS_Atlas.hpp
@@ -81,7 +81,7 @@ void Method_Solver<Solver::LBFGS_Atlas>::Iteration()
     for(int img=0; img<noi; img++)
     {
         a_norm_rms = std::max( a_norm_rms, scalar( sqrt(
-            Backend::par::reduce([] SPIRIT_LAMBDA (const Vector2 & v){ return v.squaredNorm(); }, this->atlas_directions[img]) / nos
+            Backend::par::reduce(nos, [] SPIRIT_LAMBDA (const Vector2 & v){ return v.squaredNorm(); }, this->atlas_directions[img]) / nos
         )));
     }
     scalar scaling = (a_norm_rms > maxmove) ? maxmove/a_norm_rms : 1.0;

--- a/core/include/engine/Solver_SIB.hpp
+++ b/core/include/engine/Solver_SIB.hpp
@@ -30,8 +30,8 @@ void Method_Solver<Solver::SIB>::Iteration ()
     this->Calculate_Force_Virtual(this->configurations, this->forces, this->forces_virtual);
     for (int i = 0; i < this->noi; ++i)
     {
-        auto image      = *this->systems[i]->spins;
-        auto predictor  = *this->configurations_predictor[i];
+        auto& image     = *this->systems[i]->spins;
+        auto& predictor = *this->configurations_predictor[i];
         Solver_Kernels::sib_transform(image, forces_virtual[i], predictor);
 
         auto imagep     = this->systems[i]->spins->data();

--- a/core/include/engine/Solver_SIB.hpp
+++ b/core/include/engine/Solver_SIB.hpp
@@ -30,12 +30,15 @@ void Method_Solver<Solver::SIB>::Iteration ()
     this->Calculate_Force_Virtual(this->configurations, this->forces, this->forces_virtual);
     for (int i = 0; i < this->noi; ++i)
     {
-        auto& image     = *this->systems[i]->spins;
-        auto& predictor = *this->configurations_predictor[i];
-
+        auto image      = *this->systems[i]->spins;
+        auto predictor  = *this->configurations_predictor[i];
         Solver_Kernels::sib_transform(image, forces_virtual[i], predictor);
-        Vectormath::add_c_a(1, image, predictor);
-        Vectormath::scale(predictor, 0.5);
+
+        auto imagep     = this->systems[i]->spins->data();
+        auto predictorp = this->configurations_predictor[i]->data();
+        Backend::par::apply( nos, [imagep, predictorp] SPIRIT_LAMBDA (int idx) {
+            predictorp[idx] = 0.5 * (imagep[idx] + predictorp[idx]);
+        } );
     }
 
     // Second part of the step
@@ -43,8 +46,7 @@ void Method_Solver<Solver::SIB>::Iteration ()
     this->Calculate_Force_Virtual(this->configurations_predictor, this->forces_predictor, this->forces_virtual_predictor);
     for (int i = 0; i < this->noi; ++i)
     {
-        auto& image     = *this->systems[i]->spins;
-
+        auto& image = *this->systems[i]->spins;
         Solver_Kernels::sib_transform(image, forces_virtual_predictor[i], image);
     }
 };

--- a/core/include/engine/Solver_VP_OSO.hpp
+++ b/core/include/engine/Solver_VP_OSO.hpp
@@ -21,11 +21,11 @@ void Method_Solver<Solver::VP_OSO>::Initialize ()
 
 /*
     Template instantiation of the Simulation class for use with the VP Solver.
-		The velocity projection method is often efficient for direct minimization,
-		but deals poorly with quickly varying fields or stochastic noise.
-	Paper: P. F. Bessarab et al., Method for finding mechanism and activation energy
-		   of magnetic transitions, applied to skyrmion and antivortex annihilation,
-		   Comp. Phys. Comm. 196, 335 (2015).
+        The velocity projection method is often efficient for direct minimization,
+        but deals poorly with quickly varying fields or stochastic noise.
+    Paper: P. F. Bessarab et al., Method for finding mechanism and activation energy
+            of magnetic transitions, applied to skyrmion and antivortex annihilation,
+            Comp. Phys. Comm. 196, 335 (2015).
 
     Instead of the cartesian update scheme with re-normalization, this implementation uses the orthogonal spin optimization scheme,
     described by A. Ivanov in https://arxiv.org/abs/1904.02669.
@@ -97,9 +97,9 @@ void Method_Solver<Solver::VP_OSO>::Iteration ()
 
         // Calculate the projected velocity
         if (projection_full <= 0)
+            Backend::par::assign(velocities[img], [] SPIRIT_LAMBDA () -> Vector3 {return {0, 0, 0};});
+        else
         {
-            Vectormath::fill(velocities[img], { 0,0,0 });
-        } else {
             Backend::par::apply(nos, [g,v,ratio] SPIRIT_LAMBDA (int idx) {
                 v[idx] = g[idx] * ratio;
             });
@@ -107,7 +107,7 @@ void Method_Solver<Solver::VP_OSO>::Iteration ()
 
         Backend::par::apply( nos, [sd, dt, m_temp, v, g] SPIRIT_LAMBDA (int idx) {
             sd[idx] = dt * v[idx] + 0.5/m_temp * dt * g[idx];
-        }); 
+        });
     }
     Solver_Kernels::oso_rotate( this->configurations, this->searchdir);
 }

--- a/core/include/engine/Vectormath.hpp
+++ b/core/include/engine/Vectormath.hpp
@@ -550,14 +550,6 @@ namespace Engine
         /////////////////////////////////////////////////////////////////
         //////// Vectormath-like operations
 
-        // sets sf := s
-        // sf is a scalarfield
-        // s is a scalar
-        void fill(scalarfield & sf, scalar s);
-
-        // TODO: Add the test
-        void fill(scalarfield & sf, scalar s, const intfield & mask);
-
         // Scale a scalarfield by a given value
         void scale(scalarfield & sf, scalar s);
 
@@ -573,14 +565,6 @@ namespace Engine
         // Cut off all values to remain in a certain range
         void set_range(scalarfield & sf, scalar sf_min, scalar sf_max);
 
-        // sets vf := v
-        // vf is a vectorfield
-        // v is a vector
-        void fill(vectorfield & vf, const Vector3 & v);
-        void fill(vectorfield & vf, const Vector3 & v, const intfield & mask);
-
-        // Normalize the vectors of a vectorfield
-        void normalize_vectors(vectorfield & vf);
 
         // Get the norm of a vectorfield
         void norm( const vectorfield & vf, scalarfield & norm );

--- a/core/src/engine/Hamiltonian_Gaussian.cpp
+++ b/core/src/engine/Hamiltonian_Gaussian.cpp
@@ -1,5 +1,6 @@
 #include <engine/Hamiltonian_Gaussian.hpp>
 #include <engine/Vectormath.hpp>
+#include <engine/Backend_par.hpp>
 #include <utility/Exception.hpp>
 
 using namespace Data;
@@ -82,7 +83,8 @@ namespace Engine
         if (this->energy_contributions_per_spin[0].second.size() != nos) this->energy_contributions_per_spin = { { "Gaussian", scalarfield(nos,0) } };
 
         // Set to zero
-        for (auto& pair : energy_contributions_per_spin) Vectormath::fill(pair.second, 0);
+        for (auto& pair : energy_contributions_per_spin)
+            Backend::par::assign(pair.second, [] SPIRIT_LAMBDA () {return 0;});
 
         for (int i = 0; i < this->n_gaussians; ++i)
         {

--- a/core/src/engine/Hamiltonian_Heisenberg.cpp
+++ b/core/src/engine/Hamiltonian_Heisenberg.cpp
@@ -623,14 +623,18 @@ namespace Engine
         if(idx_ddi >= 0)
             this->Gradient_DDI(spins, gradient);
 
-        energy += Backend::par::reduce( N, [s,g] SPIRIT_LAMBDA ( int idx ) { return 0.5 * g[idx].dot(s[idx]) ;} );
+        energy += Backend::par::reduce( [] SPIRIT_LAMBDA ( const Vector3 & s, const Vector3 & g ) {
+                return 0.5 * g.dot(s);
+            }, spins, gradient );
 
         // External field
         if(idx_zeeman >= 0)
         {
             Vector3 ext_field = external_field_normal * external_field_magnitude;
             this->Gradient_Zeeman(gradient);
-            energy += Backend::par::reduce( N, [s, ext_field, mu_s] SPIRIT_LAMBDA ( int idx ) { return -mu_s[idx] * ext_field.dot(s[idx]) ;} );
+            energy += Backend::par::reduce( [ext_field] SPIRIT_LAMBDA ( const Vector3 & s, const scalar & mu_s ) {
+                    return -mu_s * ext_field.dot(s);
+                }, spins, geometry->mu_s );
         }
 
         // Quadruplets

--- a/core/src/engine/Hamiltonian_Heisenberg.cpp
+++ b/core/src/engine/Hamiltonian_Heisenberg.cpp
@@ -623,7 +623,7 @@ namespace Engine
         if(idx_ddi >= 0)
             this->Gradient_DDI(spins, gradient);
 
-        energy += Backend::par::reduce( [] SPIRIT_LAMBDA ( const Vector3 & s, const Vector3 & g ) {
+        energy += Backend::par::reduce( spins.size(), [] SPIRIT_LAMBDA ( const Vector3 & s, const Vector3 & g ) {
                 return 0.5 * g.dot(s);
             }, spins, gradient );
 
@@ -632,7 +632,7 @@ namespace Engine
         {
             Vector3 ext_field = external_field_normal * external_field_magnitude;
             this->Gradient_Zeeman(gradient);
-            energy += Backend::par::reduce( [ext_field] SPIRIT_LAMBDA ( const Vector3 & s, const scalar & mu_s ) {
+            energy += Backend::par::reduce( spins.size(), [ext_field] SPIRIT_LAMBDA ( const Vector3 & s, const scalar & mu_s ) {
                     return -mu_s * ext_field.dot(s);
                 }, spins, geometry->mu_s );
         }

--- a/core/src/engine/Hamiltonian_Heisenberg.cpp
+++ b/core/src/engine/Hamiltonian_Heisenberg.cpp
@@ -227,9 +227,11 @@ namespace Engine
         for( auto& contrib : contributions )
         {
             // Allocate if not already allocated
-            if (contrib.second.size() != nos) contrib.second = scalarfield(nos, 0);
+            if (contrib.second.size() != nos)
+                contrib.second = scalarfield(nos, 0);
             // Otherwise set to zero
-            else Vectormath::fill(contrib.second, 0);
+            else
+                Backend::par::assign(contrib.second, [] SPIRIT_LAMBDA () {return 0;});
         }
 
         // External field
@@ -339,7 +341,7 @@ namespace Engine
     {
         vectorfield gradients_temp;
         gradients_temp.resize(geometry->nos);
-        Vectormath::fill(gradients_temp, {0,0,0});
+        Backend::par::assign(gradients_temp, [] SPIRIT_LAMBDA () -> Vector3 {return {0,0,0};});
         this->Gradient_DDI_Direct(spins, gradients_temp);
 
         #pragma omp parallel for
@@ -388,13 +390,13 @@ namespace Engine
         scalar Energy_DDI = 0;
         vectorfield gradients_temp;
         gradients_temp.resize(geometry->nos);
-        Vectormath::fill(gradients_temp, {0,0,0});
+        Backend::par::assign(gradients_temp, [] SPIRIT_LAMBDA () -> Vector3 {return {0,0,0};});
         this->Gradient_DDI_FFT(spins, gradients_temp);
 
         // === DEBUG: begin gradient comparison ===
             // vectorfield gradients_temp_dir;
             // gradients_temp_dir.resize(this->geometry->nos);
-            // Vectormath::fill(gradients_temp_dir, {0,0,0});
+            // Backend::par::assign(gradients_temp_dir, [] SPIRIT_LAMBDA (int idx) {return {0,0,0};});
             // Gradient_DDI_Direct(spins, gradients_temp_dir);
 
             // //get deviation
@@ -568,7 +570,7 @@ namespace Engine
     void Hamiltonian_Heisenberg::Gradient(const vectorfield & spins, vectorfield & gradient)
     {
         // Set to zero
-        Vectormath::fill(gradient, {0,0,0});
+        Backend::par::assign(gradient, [] SPIRIT_LAMBDA () -> Vector3 {return {0,0,0};});
 
         // External field
         if(idx_zeeman >= 0)
@@ -597,9 +599,8 @@ namespace Engine
 
     void Hamiltonian_Heisenberg::Gradient_and_Energy(const vectorfield & spins, vectorfield & gradient, scalar & energy)
     {
-
         // Set to zero
-        Vectormath::fill(gradient, {0,0,0});
+        Backend::par::assign(gradient, [] SPIRIT_LAMBDA () { return Vector3{0,0,0}; });
         energy = 0;
 
         auto N = spins.size();

--- a/core/src/engine/Method_MMF.cpp
+++ b/core/src/engine/Method_MMF.cpp
@@ -368,7 +368,7 @@ namespace Engine
             // Spectra was not successful in calculating an eigenvector
             Log(Log_Level::Error, Log_Sender::MMF, "Failed to calculate eigenvectors of the Hessian!");
             Log(Log_Level::Info,  Log_Sender::MMF, "Zeroing the MMF force...");
-            Vectormath::fill(force, Vector3{0,0,0});
+            Backend::par::assign(force, [] SPIRIT_LAMBDA () -> Vector3 {return {0, 0, 0};});
         }
     }
 

--- a/core/src/engine/Solver_Kernels.cpp
+++ b/core/src/engine/Solver_Kernels.cpp
@@ -89,7 +89,7 @@ namespace Solver_Kernels
     {
         int nos = searchdir.size();
         scalar theta_rms = 0;
-        theta_rms = sqrt( Backend::par::reduce([] SPIRIT_LAMBDA (const Vector3 & v){ return v.squaredNorm(); }, searchdir) / nos );
+        theta_rms = sqrt( Backend::par::reduce( nos, [] SPIRIT_LAMBDA (const Vector3 & v){ return v.squaredNorm(); }, searchdir) / nos );
         scalar scaling = (theta_rms > maxmove) ? maxmove/theta_rms : 1.0;
         return scaling;
     }

--- a/core/src/engine/Solver_Kernels.cpp
+++ b/core/src/engine/Solver_Kernels.cpp
@@ -61,11 +61,11 @@ namespace Solver_Kernels
 
             auto s  = configurations[img]->data();
             auto sd = searchdir[img].data();
-            
-            Backend::par::apply( nos, [s, sd] SPIRIT_LAMBDA (int idx) 
+
+            Backend::par::apply( nos, [s, sd] SPIRIT_LAMBDA (int idx)
                 {
                     scalar theta = (sd[idx]).norm();
-                    scalar q = cos(theta), w = 1-q, 
+                    scalar q = cos(theta), w = 1-q,
                            x = -sd[idx][0]/theta, y = -sd[idx][1]/theta, z = -sd[idx][2]/theta,
                            s1 = -y*z*w, s2 = x*z*w, s3 = -x*y*w,
                            p1 = x*sin(theta), p2 = y*sin(theta), p3 = z*sin(theta);
@@ -89,7 +89,7 @@ namespace Solver_Kernels
     {
         int nos = searchdir.size();
         scalar theta_rms = 0;
-        theta_rms = sqrt( Backend::par::reduce(searchdir, [] SPIRIT_LAMBDA (const Vector3 & v){ return v.squaredNorm(); }) / nos );
+        theta_rms = sqrt( Backend::par::reduce([] SPIRIT_LAMBDA (const Vector3 & v){ return v.squaredNorm(); }, searchdir) / nos );
         scalar scaling = (theta_rms > maxmove) ? maxmove/theta_rms : 1.0;
         return scaling;
     }
@@ -167,7 +167,7 @@ namespace Solver_Kernels
         {
             rho[n] = 1/rho[n];
         }
-        
+
         for(int img=0; img<noi; img++)
         {
             auto s = (*configurations[img]).data();

--- a/core/src/engine/Vectormath.cpp
+++ b/core/src/engine/Vectormath.cpp
@@ -62,19 +62,6 @@ namespace Vectormath
 
     /////////////////////////////////////////////////////////////////
 
-    void fill(scalarfield & sf, scalar s)
-    {
-        #pragma omp parallel for
-        for (unsigned int i = 0; i<sf.size(); ++i)
-            sf[i] = s;
-    }
-    void fill(scalarfield & sf, scalar s, const intfield & mask)
-    {
-        #pragma omp parallel for
-        for (unsigned int i=0; i<sf.size(); ++i)
-            sf[i] = mask[i]*s;
-    }
-
     void scale(scalarfield & sf, scalar s)
     {
         #pragma omp parallel for
@@ -109,26 +96,6 @@ namespace Vectormath
         #pragma omp parallel for
         for (unsigned int i = 0; i<sf.size(); ++i)
             sf[i] = std::min( std::max( sf_min, sf[i] ), sf_max );
-    }
-
-    void fill(vectorfield & vf, const Vector3 & v)
-    {
-        #pragma omp parallel for
-        for (unsigned int i=0; i<vf.size(); ++i)
-            vf[i] = v;
-    }
-    void fill(vectorfield & vf, const Vector3 & v, const intfield & mask)
-    {
-        #pragma omp parallel for
-        for (unsigned int i=0; i<vf.size(); ++i)
-            vf[i] = mask[i]*v;
-    }
-
-    void normalize_vectors(vectorfield & vf)
-    {
-        #pragma omp parallel for
-        for (unsigned int i=0; i<vf.size(); ++i)
-            vf[i].normalize();
     }
 
     void norm( const vectorfield & vf, scalarfield & norm )

--- a/core/src/io/Dataparser.cpp
+++ b/core/src/io/Dataparser.cpp
@@ -46,10 +46,9 @@ namespace IO
                 geometry.atom_types[i] = -1;
             #endif
             }
-        }
 
-        // normalize read in spins
-        Vectormath::normalize_vectors( spins );
+            spins[i].normalize();
+        }
     }
 
 

--- a/core/test/test_manifoldmath.cpp
+++ b/core/test/test_manifoldmath.cpp
@@ -2,6 +2,7 @@
 #include <engine/Vectormath_Defines.hpp>
 #include <engine/Vectormath.hpp>
 #include <engine/Manifoldmath.hpp>
+#include <engine/Backend_par.hpp>
 
 
 TEST_CASE( "Manifold operations", "[manifold]" )
@@ -53,56 +54,68 @@ TEST_CASE( "Manifold operations", "[manifold]" )
 		Engine::Manifoldmath::invert_orthogonal(v1,v2);
 		REQUIRE( Engine::Vectormath::dot(v1, v3) == Approx(-proj_prev) );
 	}
-  
+
   SECTION( "Projection: tangetial")
   {
     REQUIRE_FALSE( Engine::Vectormath::dot(v1,v2) == Approx(0) );  // Assert they are not orthogonal
-    Engine::Vectormath::normalize_vectors( v2 );    // Normalize all vector3 of v2 for projection
-    Engine::Manifoldmath::project_tangential(v1,v2); 
+    // Normalize all vector3 of v2 for projection
+    auto v2p = v2.data();
+    Engine::Backend::par::apply(v2.size(), [v2p] SPIRIT_LAMBDA (int idx) {
+        v2p[idx].normalize();
+    });
+    Engine::Manifoldmath::project_tangential(v1,v2);
     for (int i=0; i<N_check; i++)
     {
-      
+
       REQUIRE( v2[i].dot(v1[i]) == Approx(0) );
       REQUIRE( Engine::Vectormath::dot(v1,v2) == Approx(0) );
     }
   }
-  
+
   SECTION( "Distance on Greatcircle" )
   {
     // orthogonal vectors ( angle pi/2 between them )
-    
+
     vectorfield vf3( N, Vector3{ 0.0, 0.0, 1.0 } );
     vectorfield vf4( N, Vector3{ 0.0, 1.0, 0.0 } );
-    
+
     REQUIRE( Engine::Vectormath::dot( vf3, vf4) == Approx(0) );
-    Engine::Vectormath::normalize_vectors( vf3 );             // normalize components of vf3
-    Engine::Vectormath::normalize_vectors( vf4 );             // normalize components of vf4
-    
+    auto vf3p = vf3.data();
+    auto vf4p = vf4.data();
+    Engine::Backend::par::apply(vf3.size(), [vf3p, vf4p] SPIRIT_LAMBDA (int idx) {
+        vf3p[idx].normalize();
+        vf4p[idx].normalize();
+    });
+
     scalar dist = Engine::Vectormath::angle( vf3[0], vf4[0] );
     REQUIRE( dist == Approx( std::acos(-1)*0.5 ) );   // distance should be pi/2
-    
+
     // antiparallel vectors ( angle pi between them )
-    
+
     vectorfield vf5( N, Vector3{ 0.0,  1.0, 0.0 } );
     vectorfield vf6( N, Vector3{ 0.0, -1.0, 0.0 } );
-    
+
     REQUIRE( Engine::Vectormath::dot( vf5, vf6 ) == Approx(-1*N) );
-    Engine::Vectormath::normalize_vectors( vf5 );             // normalize components of vf5
-    Engine::Vectormath::normalize_vectors( vf6 );             // normalize components of vf6
-    
+    auto vf5p = vf5.data();
+    auto vf6p = vf6.data();
+    Engine::Backend::par::apply(vf5.size(), [vf5p, vf6p] SPIRIT_LAMBDA (int idx) {
+        vf5p[idx].normalize();
+        vf6p[idx].normalize();
+    });
+
     scalar dist2 = Engine::Vectormath::angle( vf5[0], vf6[0] );
     REQUIRE( dist2 == Approx( std::acos(-1) ) );      // distance should be pi
   }
-  
+
   SECTION( "Distance on Geodesic" )
   {
     vectorfield v3( N, Vector3{ 0.0, 0.0, 1.0 } );
     vectorfield v4( N, Vector3{ 0.0, 1.0, 0.0 } );
-    
+
     REQUIRE( Engine::Vectormath::dot( v3, v4 ) == Approx( 0 ) );
     Engine::Manifoldmath::normalize( v3 );
     Engine::Manifoldmath::normalize( v4 );
-    
+
     scalar dist = Engine::Manifoldmath::dist_geodesic( v3, v4 );
     scalar dist_gc = Engine::Vectormath::angle( v3[0], v4[0] );
     REQUIRE( dist == Approx( sqrt( N * dist_gc * dist_gc ) ) );


### PR DESCRIPTION
The assign and reduce parallelisation functions can now handle arbitrary numbers of function arguments, which are forwarded to the lambda.
Therefore, the lambda is now placed before the variadic arguments.
Note that they can now also be called without arguments, allowing e.g. an assignment of zero to an entire `field`.

This PR is related to issue #529.

TODO:
- [x] create variadic lambdas in backend and update usage
- [ ] replace Vectormath and Manifoldmath with backend functions to get rid of the cuda files