### PR TITLE
Hotfix qt plugin dir

### DIFF
--- a/ui-cpp/CMakeLists.txt
+++ b/ui-cpp/CMakeLists.txt
@@ -310,7 +310,7 @@ if( SPIRIT_UI_CXX_USE_QT )
                 ${QT_PLUGINS_DIR}/platforms
                 ${QT_PLUGINS_DIR}/imageformats
             DESTINATION
-                ${plugin_dest_dir}/PlugIns
+                ${plugin_dest_dir}/plugins
             COMPONENT
                 Runtime
             FILES_MATCHING


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read the [README](https://github.com/spirit-code/spirit/blob/develop/README.md)
- [x] I have read the [CONTRIBUTING](https://github.com/spirit-code/spirit/blob/develop/docs/CONTRIBUTING.md) document

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have branched from the `develop` branch
- [x] My commits are in nice logical chunks
- [x] My contribution is fully baked and is ready to be merged as is **or**
      I have cleanly laid out what this pull request should achieve in the end

------------------------------

### Description
<!--
    Describe briefly what your pull request proposes to implement.
    Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to achieve.
    You can also use the `fixes #1234` syntax to refer to specific issues.
-->
Qt cannot find plugins directory, i.e. xcb could not be found. Unless the user specifies the plugin path in the `qt.conf `file by the `spirit` binary or specifying the plugin path as an environmental variable, the application fails. Qt defaults to ${plugin_dest_dir}/plugins **not** ${plugin_dest_dir}/PlugIns, which is an issue for case sensitive file systems. This simple patch corrects this, for master and stable tags.

This was found on Debian/Buster, which should be a problem on any *nix system like Ubuntu.