### PR TITLE
Update geometry & spin current widgets

### DIFF
--- a/core/src/Spirit/Geometry.cpp
+++ b/core/src/Spirit/Geometry.cpp
@@ -120,6 +120,8 @@ void Helper_State_Set_Geometry(
 void Geometry_Set_Boundary_Conditions( State * state, const bool * periodical, int idx_image, int idx_chain ) noexcept
 try
 {
+    check_state( state );
+
     // Fetch correct indices and pointers
     auto [image, chain] = from_indices( state, idx_image, idx_chain );
     throw_if_nullptr( periodical, "periodical" );

--- a/core/src/Spirit/Parameters_LLG.cpp
+++ b/core/src/Spirit/Parameters_LLG.cpp
@@ -329,8 +329,8 @@ try
         case( Data::SC_Model::MONOLAYER ):
         {
             Log( Utility::Log_Level::Parameter, Utility::Log_Sender::API,
-                 "Spin Current: using the using the spin-transfer torque model (pinned monolayer approximation)",
-                 idx_image, idx_chain );
+                 "Spin Current: using the spin-transfer torque model (pinned monolayer approximation)", idx_image,
+                 idx_chain );
             break;
         }
     }

--- a/ui-cpp/ui-imgui/include/geometry_widget.hpp
+++ b/ui-cpp/ui-imgui/include/geometry_widget.hpp
@@ -23,6 +23,9 @@ struct GeometryWidget : public WidgetBase
 
     int n_cells[3]{ 1, 1, 1 };
     int n_basis_atoms = 1;
+
+    std::array<bool, 3> boundary_conditions{};
+
     scalar bravais_vector_a[3]{ 0, 0, 0 };
     scalar bravais_vector_b[3]{ 0, 0, 0 };
     scalar bravais_vector_c[3]{ 0, 0, 0 };

--- a/ui-cpp/ui-imgui/include/hamiltonian_widget.hpp
+++ b/ui-cpp/ui-imgui/include/hamiltonian_widget.hpp
@@ -24,8 +24,6 @@ struct HamiltonianWidget : public WidgetBase
     std::shared_ptr<State> state;
     RenderingLayer & rendering_layer;
 
-    std::array<bool, 3> boundary_conditions;
-
     std::vector<scalar> mu_s;
 
     bool external_field_active;

--- a/ui-cpp/ui-imgui/include/parameters_widget.hpp
+++ b/ui-cpp/ui-imgui/include/parameters_widget.hpp
@@ -94,13 +94,14 @@ struct Parameters
         scalar temperature_gradient_direction[3]{ 1, 0, 0 };
         scalar temperature_gradient_inclination = 0;
 
-        // - true:  use gradient approximation for STT
-        // - false: use pinned monolayer approximation with current in z-direction
-        bool stt_use_gradient = true;
+        // 0: use pinned monolayer approximation with current in z-direction
+        // 1:  use gradient approximation for STT
+        int spin_current_model{};
+
         // Spin transfer torque parameter (prop to injected current density)
-        scalar stt_magnitude = 0;
+        scalar spin_current_magnitude{ 0.0 };
         // Spin current polarisation normal vector
-        scalar stt_polarisation_normal[3]{ 1, 0, 0 };
+        std::array<scalar, 3> spin_current_direction{ 1.0, 0.0, 0.0 };
 
         // Do direct minimization instead of dynamics
         bool direct_minimization = false;

--- a/ui-cpp/ui-imgui/src/geometry_widget.cpp
+++ b/ui-cpp/ui-imgui/src/geometry_widget.cpp
@@ -1,6 +1,7 @@
 #include <geometry_widget.hpp>
 #include <widgets.hpp>
 
+#include <Spirit/Chain.h>
 #include <Spirit/Geometry.h>
 
 #include <imgui/imgui.h>
@@ -19,6 +20,8 @@ GeometryWidget::GeometryWidget( bool & show, std::shared_ptr<State> state, Rende
 
 void GeometryWidget::update_data()
 {
+    Geometry_Get_Boundary_Conditions( state.get(), boundary_conditions.data() );
+
     system_dimensionality = Geometry_Get_Dimensionality( state.get() );
     Geometry_Get_N_Cells( state.get(), n_cells );
     Geometry_Get_Center( this->state.get(), system_center );
@@ -31,6 +34,35 @@ void GeometryWidget::update_data()
 
 void GeometryWidget::show_content()
 {
+    ImGui::Indent( 15 );
+    ImGui::TextUnformatted( "Periodical boundary conditions" );
+    ImGui::Indent( 15 );
+    ImGui::TextUnformatted( "(a, b, c)" );
+    ImGui::SameLine();
+    bool update_bc = false;
+    if( ImGui::Checkbox( "##periodical_a", &boundary_conditions[0] ) )
+        update_bc = true;
+    ImGui::SameLine();
+    if( ImGui::Checkbox( "##periodical_b", &boundary_conditions[1] ) )
+        update_bc = true;
+    ImGui::SameLine();
+    if( ImGui::Checkbox( "##periodical_c", &boundary_conditions[2] ) )
+        update_bc = true;
+    ImGui::Indent( -30 );
+    if( update_bc )
+    {
+        // The Hamiltonians, for each image in the chain, have a shared pointer to the geometry.
+        // So technically we only have to update the geometry object for one image.
+        // *But* updating the boundary conditions involves some bookkeeping in the
+        // hamiltonian interactions and therefore we call `Geometry_Set_Boundary_Conditions` for each image in the
+        // chain. This way we can be sure that the necessary bookkeeping is performed for all hamiltonians
+        for( int idx_image = 0; idx_image < Chain_Get_NOI( state.get() ); idx_image++ )
+        {
+            Geometry_Set_Boundary_Conditions( state.get(), boundary_conditions.data(), idx_image );
+        }
+        rendering_layer.update_boundingbox();
+    }
+
     static std::vector<std::string> bravais_lattice_types{
         "Irregular", "Rectilinear", "Simple cubic", "Hexagonal (2D)", "Hexagonal (2D, 60deg)", "Hexagonal (2D, 120deg)",
         "HCP",       "BCC",         "FCC",

--- a/ui-cpp/ui-imgui/src/hamiltonian_widget.cpp
+++ b/ui-cpp/ui-imgui/src/hamiltonian_widget.cpp
@@ -69,30 +69,6 @@ void HamiltonianWidget::show_content()
 
         if( hamiltonian_type == "Heisenberg" )
         {
-            ImGui::Indent( 15 );
-            ImGui::TextUnformatted( "Periodical boundary conditions" );
-            ImGui::Indent( 15 );
-            ImGui::TextUnformatted( "(a, b, c)" );
-            ImGui::SameLine();
-            bool update_bc = false;
-            if( ImGui::Checkbox( "##periodical_a", &boundary_conditions[0] ) )
-                update_bc = true;
-            ImGui::SameLine();
-            if( ImGui::Checkbox( "##periodical_b", &boundary_conditions[1] ) )
-                update_bc = true;
-            ImGui::SameLine();
-            if( ImGui::Checkbox( "##periodical_c", &boundary_conditions[2] ) )
-                update_bc = true;
-            ImGui::Indent( -15 );
-            ImGui::Indent( -15 );
-            if( update_bc )
-            {
-                Geometry_Set_Boundary_Conditions( state.get(), boundary_conditions.data() );
-                rendering_layer.update_boundingbox();
-            }
-
-            ImGui::Dummy( { 0, 10 } );
-
             ImGui::TextUnformatted( "Spin moment mu_s [mu_B]" );
             ImGui::Indent( 15 );
             ImGui::SetNextItemWidth( 80 );
@@ -491,9 +467,6 @@ void HamiltonianWidget::update_data_heisenberg()
 {
     int n_basis_atoms = Geometry_Get_N_Cell_Atoms( state.get() );
     mu_s.resize( n_basis_atoms );
-
-    // Boundary conditions
-    Geometry_Get_Boundary_Conditions( state.get(), boundary_conditions.data() );
 
     // mu_s
     Geometry_Get_mu_s( state.get(), mu_s.data() );

--- a/ui-cpp/ui-imgui/src/parameters_widget.cpp
+++ b/ui-cpp/ui-imgui/src/parameters_widget.cpp
@@ -145,6 +145,10 @@ void ParametersWidget::show_content()
 
         ImGui::Dummy( { 0, 10 } );
 
+        // --------------------------------------
+        // Convergence, damping & timestep
+        // --------------------------------------
+
         ImGui::TextUnformatted( "Convergence limit" );
         ImGui::SameLine();
         ImGui::SetNextItemWidth( 80 );
@@ -170,6 +174,10 @@ void ParametersWidget::show_content()
             Parameters_LLG_Set_Damping( state.get(), parameters_llg.damping );
 
         ImGui::Dummy( { 0, 10 } );
+
+        // --------------------------------------
+        // Temperature
+        // --------------------------------------
 
         ImGui::TextUnformatted( "Temperature" );
         ImGui::Indent( 15 );
@@ -202,37 +210,50 @@ void ParametersWidget::show_content()
 
         ImGui::Dummy( { 0, 10 } );
 
+        // --------------------------------------
+        // Spin currents
+        // --------------------------------------
+
         ImGui::TextUnformatted( "Spin torques" );
         ImGui::Indent( 15 );
-        std::vector<const char *> stt_approximation{ "Perpendicular current (STT)", "Gradient (SOT)" };
-        int stt_index = int( parameters_llg.stt_use_gradient );
+
         ImGui::SetNextItemWidth( 220 );
-        if( ImGui::Combo( "##approximation", &stt_index, stt_approximation.data(), int( stt_approximation.size() ) ) )
+
+        std::vector<const char *> spin_current_model_names{ "Monolayer (STT)", "Gradient (SOT)" };
+
+        bool set_spin_current{ false };
+        if( ImGui::Combo(
+                "##model", &parameters_llg.spin_current_model, spin_current_model_names.data(),
+                static_cast<int>( spin_current_model_names.size() ) ) )
         {
-            parameters_llg.stt_use_gradient = bool( stt_index );
-            Parameters_LLG_Set_STT(
-                state.get(), parameters_llg.stt_use_gradient, parameters_llg.stt_magnitude,
-                parameters_llg.stt_polarisation_normal );
+            set_spin_current = true;
         }
         ImGui::TextUnformatted( "Magnitude" );
         ImGui::SameLine();
         ImGui::SetNextItemWidth( 80 );
         if( widgets::InputScalar(
-                "##llg_stt_magnitude", &parameters_llg.stt_magnitude, 0, 0, "%.5f",
+                "##llg_spin_current_magnitude", &parameters_llg.spin_current_magnitude, 0, 0, "%.5f",
                 ImGuiInputTextFlags_EnterReturnsTrue ) )
-            Parameters_LLG_Set_STT(
-                state.get(), parameters_llg.stt_use_gradient, parameters_llg.stt_magnitude,
-                parameters_llg.stt_polarisation_normal );
-        ImGui::TextUnformatted( "Polarisation" );
+        {
+            set_spin_current = true;
+        }
+        ImGui::TextUnformatted( "Direction" );
         ImGui::SameLine();
         ImGui::SetNextItemWidth( 180 );
         if( widgets::InputScalar3(
-                "##llg_stt_polarisation_normal", parameters_llg.stt_polarisation_normal, "%.2f",
+                "##llg_spin_current_direction", parameters_llg.spin_current_direction.data(), "%.2f",
                 ImGuiInputTextFlags_EnterReturnsTrue ) )
-            Parameters_LLG_Set_STT(
-                state.get(), parameters_llg.stt_use_gradient, parameters_llg.stt_magnitude,
-                parameters_llg.stt_polarisation_normal );
+        {
+            set_spin_current = true;
+        }
         ImGui::Indent( -15 );
+
+        if( set_spin_current )
+        {
+            Parameters_LLG_Set_Spin_Current(
+                state.get(), parameters_llg.spin_current_model, parameters_llg.spin_current_magnitude,
+                parameters_llg.spin_current_direction.data() );
+        }
     }
     else if( ui_shared_state.selected_mode == GUI_Mode::MC )
     {
@@ -769,9 +790,11 @@ void ParametersWidget::update_data()
     parameters_llg.temperature       = Parameters_LLG_Get_Temperature( state.get() );
     Parameters_LLG_Get_Temperature_Gradient(
         state.get(), parameters_llg.temperature_gradient_direction, &parameters_llg.temperature_gradient_inclination );
-    Parameters_LLG_Get_STT(
-        state.get(), &parameters_llg.stt_use_gradient, &parameters_llg.stt_magnitude,
-        parameters_llg.stt_polarisation_normal );
+
+    Parameters_LLG_Get_Spin_Current(
+        state.get(), &parameters_llg.spin_current_model, &parameters_llg.spin_current_magnitude,
+        parameters_llg.spin_current_direction.data() );
+
     parameters_llg.direct_minimization = Parameters_LLG_Get_Direct_Minimization( state.get() );
     // Output
     parameters_llg.output_folder   = Parameters_LLG_Get_Output_Folder( state.get() );

--- a/ui-cpp/ui-qt/include/GeometryWidget.hpp
+++ b/ui-cpp/ui-qt/include/GeometryWidget.hpp
@@ -27,6 +27,7 @@ signals:
 
 private slots:
     void setNCells();
+    void set_boundary_conditions();
 
 private:
     void Setup_Input_Validators();

--- a/ui-cpp/ui-qt/include/HamiltonianHeisenbergWidget.hpp
+++ b/ui-cpp/ui-qt/include/HamiltonianHeisenbergWidget.hpp
@@ -30,7 +30,6 @@ public:
     void updateData();
 
 private slots:
-    void set_boundary_conditions();
     void set_mu_s();
     void set_external_field();
     void set_anisotropy();

--- a/ui-cpp/ui-qt/src/GeometryWidget.cpp
+++ b/ui-cpp/ui-qt/src/GeometryWidget.cpp
@@ -2,7 +2,9 @@
 
 #include <QtWidgets>
 
+#include <Spirit/Chain.h>
 #include <Spirit/Geometry.h>
+#include <Spirit/System.h>
 
 GeometryWidget::GeometryWidget( std::shared_ptr<State> state, SpinWidget * spinWidget )
 {
@@ -33,6 +35,13 @@ GeometryWidget::GeometryWidget( std::shared_ptr<State> state, SpinWidget * spinW
 
 void GeometryWidget::updateData()
 {
+    // Boundary conditions
+    bool boundary_conditions[3];
+    Geometry_Get_Boundary_Conditions( state.get(), boundary_conditions );
+    this->checkBox_periodical_a->setChecked( boundary_conditions[0] );
+    this->checkBox_periodical_b->setChecked( boundary_conditions[1] );
+    this->checkBox_periodical_c->setChecked( boundary_conditions[2] );
+
     int n_cells[3];
     Geometry_Get_N_Cells( this->state.get(), n_cells );
     this->lineEdit_n_cells_a->setText( QString::number( n_cells[0] ) );
@@ -84,6 +93,25 @@ void GeometryWidget::setNCells()
     emit updateNeeded();
 }
 
+void GeometryWidget::set_boundary_conditions()
+{
+    // Boundary conditions
+    const std::array<bool, 3> boundary_conditions{ this->checkBox_periodical_a->isChecked(),
+                                                   this->checkBox_periodical_b->isChecked(),
+                                                   this->checkBox_periodical_c->isChecked() };
+
+    // The Hamiltonians, for each image in the chain, have a shared pointer to the geometry.
+    // So technically we only have to update the geometry object for one image.
+    // *But* updating the boundary conditions involves some bookkeeping in the
+    // hamiltonian interactions and therefore we call `Geometry_Set_Boundary_Conditions` for each image in the chain.
+    // This way we can be sure that the necessary bookkeeping is performed for all hamiltonians
+    for( int idx_image = 0; idx_image < Chain_Get_NOI( state.get() ); idx_image++ )
+    {
+        Geometry_Set_Boundary_Conditions( state.get(), boundary_conditions.data(), idx_image );
+    }
+    this->spinWidget->updateBoundingBoxIndicators();
+}
+
 void GeometryWidget::Setup_Input_Validators()
 {
     this->lineEdit_n_cells_a->setValidator( this->number_validator_unsigned );
@@ -93,6 +121,11 @@ void GeometryWidget::Setup_Input_Validators()
 
 void GeometryWidget::Setup_Slots()
 {
+    // Boundary Conditions
+    connect( this->checkBox_periodical_a, SIGNAL( stateChanged( int ) ), this, SLOT( set_boundary_conditions() ) );
+    connect( this->checkBox_periodical_b, SIGNAL( stateChanged( int ) ), this, SLOT( set_boundary_conditions() ) );
+    connect( this->checkBox_periodical_c, SIGNAL( stateChanged( int ) ), this, SLOT( set_boundary_conditions() ) );
+
     connect( this->lineEdit_n_cells_a, SIGNAL( returnPressed() ), this, SLOT( setNCells() ) );
     connect( this->lineEdit_n_cells_b, SIGNAL( returnPressed() ), this, SLOT( setNCells() ) );
     connect( this->lineEdit_n_cells_c, SIGNAL( returnPressed() ), this, SLOT( setNCells() ) );

--- a/ui-cpp/ui-qt/src/HamiltonianHeisenbergWidget.cpp
+++ b/ui-cpp/ui-qt/src/HamiltonianHeisenbergWidget.cpp
@@ -63,13 +63,6 @@ void HamiltonianHeisenbergWidget::Load_Contents()
     int n_basis_atoms = Geometry_Get_N_Cell_Atoms( state.get() );
     std::vector<scalar> mu_s( n_basis_atoms );
 
-    // Boundary conditions
-    bool boundary_conditions[3];
-    Geometry_Get_Boundary_Conditions( state.get(), boundary_conditions );
-    this->checkBox_aniso_periodical_a->setChecked( boundary_conditions[0] );
-    this->checkBox_aniso_periodical_b->setChecked( boundary_conditions[1] );
-    this->checkBox_aniso_periodical_c->setChecked( boundary_conditions[2] );
-
     // mu_s
     Geometry_Get_mu_s( state.get(), mu_s.data() );
     this->lineEdit_muSpin_aniso->setText( QString::number( mu_s[0] ) );
@@ -141,40 +134,6 @@ void HamiltonianHeisenbergWidget::Load_Contents()
 // -----------------------------------------------------------------------------------
 // -------------------------- Setters ------------------------------------------------
 // -----------------------------------------------------------------------------------
-
-void HamiltonianHeisenbergWidget::set_boundary_conditions()
-{
-    // Closure to set the parameters of a specific spin system
-    auto apply = [this]( int idx_image ) -> void
-    {
-        // Boundary conditions
-        bool boundary_conditions[3];
-        boundary_conditions[0] = this->checkBox_aniso_periodical_a->isChecked();
-        boundary_conditions[1] = this->checkBox_aniso_periodical_b->isChecked();
-        boundary_conditions[2] = this->checkBox_aniso_periodical_c->isChecked();
-        Geometry_Set_Boundary_Conditions( state.get(), boundary_conditions, idx_image );
-    };
-
-    if( this->comboBox_Hamiltonian_Ani_ApplyTo->currentText() == "Current Image" )
-    {
-        apply( System_Get_Index( state.get() ) );
-    }
-    else if( this->comboBox_Hamiltonian_Ani_ApplyTo->currentText() == "Current Image Chain" )
-    {
-        for( int i = 0; i < Chain_Get_NOI( state.get() ); ++i )
-        {
-            apply( i );
-        }
-    }
-    else if( this->comboBox_Hamiltonian_Ani_ApplyTo->currentText() == "All Images" )
-    {
-        for( int img = 0; img < Chain_Get_NOI( state.get() ); ++img )
-        {
-            apply( img );
-        }
-    }
-    this->spinWidget->updateBoundingBoxIndicators();
-}
 
 void HamiltonianHeisenbergWidget::set_mu_s()
 {
@@ -549,13 +508,6 @@ void HamiltonianHeisenbergWidget::Setup_Input_Validators()
 
 void HamiltonianHeisenbergWidget::Setup_Slots()
 {
-    // Boundary Conditions
-    connect(
-        this->checkBox_aniso_periodical_a, SIGNAL( stateChanged( int ) ), this, SLOT( set_boundary_conditions() ) );
-    connect(
-        this->checkBox_aniso_periodical_b, SIGNAL( stateChanged( int ) ), this, SLOT( set_boundary_conditions() ) );
-    connect(
-        this->checkBox_aniso_periodical_c, SIGNAL( stateChanged( int ) ), this, SLOT( set_boundary_conditions() ) );
     // mu_s
     connect( this->lineEdit_muSpin_aniso, SIGNAL( returnPressed() ), this, SLOT( set_mu_s() ) );
     // External Field

--- a/ui-cpp/ui-qt/src/ParametersWidget.cpp
+++ b/ui-cpp/ui-qt/src/ParametersWidget.cpp
@@ -13,18 +13,26 @@
 #include <Spirit/Simulation.h>
 #include <Spirit/System.h>
 
-// Small function for normalization of vectors
-#define Exception_Division_by_zero 6666
 template<typename T>
-void normalize( T v[3] )
+bool normalize( T & vec )
 {
-    T len = 0.0;
-    for( int i = 0; i < 3; ++i )
-        len += std::pow( v[i], 2 );
-    if( len == 0.0 )
-        throw Exception_Division_by_zero;
-    for( int i = 0; i < 3; ++i )
-        v[i] /= std::sqrt( len );
+    scalar norm{ 0.0 };
+    for( const auto & elem : vec )
+    {
+        norm += elem;
+    }
+    if( norm < std::numeric_limits<scalar>::epsilon() )
+    {
+        return false;
+    }
+
+    norm = std::sqrt( norm );
+    for( auto & elem : vec )
+    {
+        elem /= norm;
+    }
+
+    return true;
 }
 
 ParametersWidget::ParametersWidget( std::shared_ptr<State> state )
@@ -79,15 +87,21 @@ void ParametersWidget::Load_Parameters_Contents()
     // Converto to PicoSeconds
     d = Parameters_LLG_Get_Time_Step( state.get() );
     this->lineEdit_dt->setText( QString::number( d ) );
+
     // Spin polarized current
-    Parameters_LLG_Get_STT( state.get(), &b1, &d, vd );
-    this->radioButton_stt_gradient->setChecked( b1 );
-    this->doubleSpinBox_llg_stt_magnitude->setValue( d );
-    this->doubleSpinBox_llg_stt_polarisation_x->setValue( vd[0] );
-    this->doubleSpinBox_llg_stt_polarisation_y->setValue( vd[1] );
-    this->doubleSpinBox_llg_stt_polarisation_z->setValue( vd[2] );
-    if( d > 0.0 )
+    int spin_current_model{};
+    scalar spin_current_magnitude{};
+    std::array<double, 3> spin_current_direction{};
+    Parameters_LLG_Get_Spin_Current(
+        state.get(), &spin_current_model, &spin_current_magnitude, spin_current_direction.data() );
+    this->comboBox_spin_current_model->setCurrentIndex( spin_current_model );
+    this->doubleSpinBox_llg_stt_magnitude->setValue( spin_current_magnitude );
+    this->doubleSpinBox_llg_stt_polarisation_x->setValue( spin_current_direction[0] );
+    this->doubleSpinBox_llg_stt_polarisation_y->setValue( spin_current_direction[1] );
+    this->doubleSpinBox_llg_stt_polarisation_z->setValue( spin_current_direction[2] );
+    if( spin_current_magnitude > 0.0 )
         this->checkBox_llg_stt->setChecked( true );
+
     // Temperature
     d = Parameters_LLG_Get_Temperature( state.get() );
     this->doubleSpinBox_llg_temperature->setValue( d );
@@ -268,36 +282,23 @@ void ParametersWidget::set_parameters_llg()
         Parameters_LLG_Set_Damping( this->state.get(), d, idx_image );
 
         // Spin polarised current
-        b1 = this->radioButton_stt_gradient->isChecked();
-        if( this->checkBox_llg_stt->isChecked() )
-            d = this->doubleSpinBox_llg_stt_magnitude->value();
-        else
-            d = 0.0;
-        vd[0] = doubleSpinBox_llg_stt_polarisation_x->value();
-        vd[1] = doubleSpinBox_llg_stt_polarisation_y->value();
-        vd[2] = doubleSpinBox_llg_stt_polarisation_z->value();
-        try
+        const int spin_current_model = this->comboBox_spin_current_model->currentIndex();
+        const scalar spin_current_magnitude
+            = this->checkBox_llg_stt->isChecked() ? this->doubleSpinBox_llg_stt_magnitude->value() : 0.0;
+
+        std::array<double, 3> spin_current_direction{ doubleSpinBox_llg_stt_polarisation_x->value(),
+                                                      doubleSpinBox_llg_stt_polarisation_y->value(),
+                                                      doubleSpinBox_llg_stt_polarisation_z->value() };
+
+        bool success = normalize( spin_current_direction );
+        if( !success )
         {
-            normalize( vd );
+            spin_current_direction = { 0.0, 0.0, 1.0 };
+            Log_Send( state.get(), Log_Level_Warning, Log_Sender_UI, "s_c_vec = {0,0,0} replaced by {0,0,1}" );
         }
-        catch( int ex )
-        {
-            if( ex == Exception_Division_by_zero )
-            {
-                vd[0] = 0.0;
-                vd[1] = 0.0;
-                vd[2] = 1.0;
-                Log_Send( state.get(), Log_Level_Warning, Log_Sender_UI, "s_c_vec = {0,0,0} replaced by {0,0,1}" );
-                doubleSpinBox_llg_stt_polarisation_x->setValue( 0.0 );
-                doubleSpinBox_llg_stt_polarisation_y->setValue( 0.0 );
-                doubleSpinBox_llg_stt_polarisation_z->setValue( 1.0 );
-            }
-            else
-            {
-                throw( ex );
-            }
-        }
-        Parameters_LLG_Set_STT( state.get(), b1, d, vd, idx_image );
+
+        Parameters_LLG_Set_Spin_Current(
+            state.get(), spin_current_model, spin_current_magnitude, spin_current_direction.data() );
 
         // Temperature
         if( this->checkBox_llg_temperature->isChecked() )
@@ -627,8 +628,9 @@ void ParametersWidget::Setup_Parameters_Slots()
     connect( this->lineEdit_llg_temperature_dir_y, SIGNAL( editingFinished() ), this, SLOT( set_parameters_llg() ) );
     connect( this->lineEdit_llg_temperature_dir_z, SIGNAL( editingFinished() ), this, SLOT( set_parameters_llg() ) );
     // STT
-    connect( this->radioButton_stt_gradient, SIGNAL( clicked() ), this, SLOT( set_parameters_llg() ) );
-    connect( this->radioButton_stt_monolayer, SIGNAL( clicked() ), this, SLOT( set_parameters_llg() ) );
+    connect(
+        this->comboBox_spin_current_model, SIGNAL( currentIndexChanged( int ) ), this, SLOT( set_parameters_llg() ) );
+
     connect( this->checkBox_llg_stt, SIGNAL( stateChanged( int ) ), this, SLOT( set_parameters_llg() ) );
     connect( this->doubleSpinBox_llg_stt_magnitude, SIGNAL( editingFinished() ), this, SLOT( set_parameters_llg() ) );
     connect(

--- a/ui-cpp/ui-qt/ui/GeometryWidget.ui
+++ b/ui-cpp/ui-qt/ui/GeometryWidget.ui
@@ -56,27 +56,7 @@
        <property name="bottomMargin">
         <number>0</number>
        </property>
-       <item row="1" column="0">
-        <widget class="QLabel" name="label_2">
-         <property name="text">
-          <string>This feature is not yet finished and may crash!</string>
-         </property>
-        </widget>
-       </item>
-       <item row="3" column="0">
-        <spacer name="verticalSpacer">
-         <property name="orientation">
-          <enum>Qt::Vertical</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>20</width>
-           <height>40</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
-       <item row="2" column="0">
+       <item row="5" column="0">
         <layout class="QGridLayout" name="gridLayout_79">
          <item row="0" column="1">
           <widget class="QLineEdit" name="lineEdit_n_cells_a">
@@ -138,6 +118,47 @@
           </widget>
          </item>
         </layout>
+       </item>
+       <item row="3" column="0">
+        <widget class="QCheckBox" name="checkBox_periodical_b">
+         <property name="text">
+          <string>Periodical b</string>
+         </property>
+        </widget>
+       </item>
+       <item row="6" column="0">
+        <spacer name="verticalSpacer">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item row="1" column="0">
+        <widget class="QLabel" name="label_2">
+         <property name="text">
+          <string>This feature is not yet finished and may crash!</string>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="0">
+        <widget class="QCheckBox" name="checkBox_periodical_a">
+         <property name="text">
+          <string>Periodical a</string>
+         </property>
+        </widget>
+       </item>
+       <item row="4" column="0">
+        <widget class="QCheckBox" name="checkBox_periodical_c">
+         <property name="text">
+          <string>Periodical c</string>
+         </property>
+        </widget>
        </item>
       </layout>
      </widget>

--- a/ui-cpp/ui-qt/ui/HamiltonianHeisenbergWidget.ui
+++ b/ui-cpp/ui-qt/ui/HamiltonianHeisenbergWidget.ui
@@ -27,8 +27,8 @@
        <rect>
         <x>0</x>
         <y>0</y>
-        <width>376</width>
-        <height>1136</height>
+        <width>382</width>
+        <height>1142</height>
        </rect>
       </property>
       <layout class="QGridLayout" name="gridLayout_29">
@@ -47,9 +47,48 @@
        <item row="14" column="0">
         <layout class="QGridLayout" name="gridLayout_2">
          <item row="17" column="1">
-          <layout class="QGridLayout" name="gridLayout_dmi">
+          <layout class="QGridLayout" name="gridLayout_6">
+           <item row="0" column="0">
+            <widget class="QSpinBox" name="spinBox_ddi_n_periodic_a"/>
+           </item>
+           <item row="0" column="1">
+            <widget class="QSpinBox" name="spinBox_ddi_n_periodic_b"/>
+           </item>
            <item row="0" column="2">
-            <spacer name="horizontalSpacer_6">
+            <widget class="QSpinBox" name="spinBox_ddi_n_periodic_c"/>
+           </item>
+          </layout>
+         </item>
+         <item row="11" column="1">
+          <spacer name="verticalSpacer_9">
+           <property name="orientation">
+            <enum>Qt::Vertical</enum>
+           </property>
+           <property name="sizeType">
+            <enum>QSizePolicy::Fixed</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>20</width>
+             <height>10</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+         <item row="7" column="1">
+          <layout class="QGridLayout" name="gridLayout_42">
+           <item row="0" column="0">
+            <widget class="QLineEdit" name="lineEdit_ani_aniso">
+             <property name="maximumSize">
+              <size>
+               <width>40</width>
+               <height>16777215</height>
+              </size>
+             </property>
+            </widget>
+           </item>
+           <item row="0" column="1">
+            <spacer name="horizontalSpacer_29">
              <property name="orientation">
               <enum>Qt::Horizontal</enum>
              </property>
@@ -61,19 +100,254 @@
              </property>
             </spacer>
            </item>
-           <item row="0" column="0">
-            <widget class="QLabel" name="label_4">
+          </layout>
+         </item>
+         <item row="12" column="0">
+          <widget class="QCheckBox" name="checkBox_dmi">
+           <property name="text">
+            <string>DMI</string>
+           </property>
+          </widget>
+         </item>
+         <item row="5" column="0">
+          <layout class="QGridLayout" name="gridLayout_40">
+           <item row="2" column="0">
+            <spacer name="horizontalSpacer_32">
+             <property name="orientation">
+              <enum>Qt::Horizontal</enum>
+             </property>
+             <property name="sizeType">
+              <enum>QSizePolicy::Minimum</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>30</width>
+               <height>20</height>
+              </size>
+             </property>
+            </spacer>
+           </item>
+           <item row="2" column="1">
+            <widget class="QLabel" name="label_15">
+             <property name="maximumSize">
+              <size>
+               <width>100</width>
+               <height>16777215</height>
+              </size>
+             </property>
              <property name="text">
-              <string>Number of Shells</string>
+              <string>Direction (x,y,z)</string>
+             </property>
+            </widget>
+           </item>
+           <item row="1" column="1">
+            <widget class="QLabel" name="label_25">
+             <property name="text">
+              <string>mu_spin</string>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </item>
+         <item row="17" column="0">
+          <layout class="QGridLayout" name="gridLayout_7">
+           <item row="0" column="0">
+            <spacer name="horizontalSpacer_8">
+             <property name="orientation">
+              <enum>Qt::Horizontal</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>40</width>
+               <height>20</height>
+              </size>
+             </property>
+            </spacer>
+           </item>
+           <item row="0" column="1">
+            <widget class="QLabel" name="label_6">
+             <property name="text">
+              <string>periodic images</string>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </item>
+         <item row="16" column="0">
+          <widget class="QCheckBox" name="checkBox_ddi">
+           <property name="text">
+            <string>Dipole-dipole</string>
+           </property>
+          </widget>
+         </item>
+         <item row="5" column="1">
+          <layout class="QGridLayout" name="gridLayout_32">
+           <item row="1" column="1">
+            <widget class="QLineEdit" name="lineEdit_extHx_aniso">
+             <property name="maximumSize">
+              <size>
+               <width>40</width>
+               <height>16777215</height>
+              </size>
+             </property>
+            </widget>
+           </item>
+           <item row="1" column="2">
+            <widget class="QLineEdit" name="lineEdit_extHy_aniso">
+             <property name="maximumSize">
+              <size>
+               <width>40</width>
+               <height>16777215</height>
+              </size>
+             </property>
+            </widget>
+           </item>
+           <item row="1" column="5">
+            <spacer name="horizontalSpacer_24">
+             <property name="orientation">
+              <enum>Qt::Horizontal</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>40</width>
+               <height>20</height>
+              </size>
+             </property>
+            </spacer>
+           </item>
+           <item row="1" column="3">
+            <widget class="QLineEdit" name="lineEdit_extHz_aniso">
+             <property name="maximumSize">
+              <size>
+               <width>40</width>
+               <height>16777215</height>
+              </size>
              </property>
             </widget>
            </item>
            <item row="0" column="1">
-            <widget class="QSpinBox" name="spinBox_nshells_dmi"/>
+            <widget class="QLineEdit" name="lineEdit_muSpin_aniso">
+             <property name="maximumSize">
+              <size>
+               <width>40</width>
+               <height>16777215</height>
+              </size>
+             </property>
+            </widget>
            </item>
           </layout>
          </item>
-         <item row="15" column="1">
+         <item row="8" column="1">
+          <layout class="QGridLayout" name="gridLayout_47">
+           <item row="0" column="0">
+            <widget class="QLineEdit" name="lineEdit_anix_aniso">
+             <property name="maximumSize">
+              <size>
+               <width>40</width>
+               <height>16777215</height>
+              </size>
+             </property>
+            </widget>
+           </item>
+           <item row="0" column="1">
+            <widget class="QLineEdit" name="lineEdit_aniy_aniso">
+             <property name="maximumSize">
+              <size>
+               <width>40</width>
+               <height>16777215</height>
+              </size>
+             </property>
+            </widget>
+           </item>
+           <item row="0" column="2">
+            <widget class="QLineEdit" name="lineEdit_aniz_aniso">
+             <property name="maximumSize">
+              <size>
+               <width>40</width>
+               <height>16777215</height>
+              </size>
+             </property>
+            </widget>
+           </item>
+           <item row="0" column="3">
+            <spacer name="horizontalSpacer_35">
+             <property name="orientation">
+              <enum>Qt::Horizontal</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>40</width>
+               <height>20</height>
+              </size>
+             </property>
+            </spacer>
+           </item>
+          </layout>
+         </item>
+         <item row="18" column="1">
+          <widget class="QDoubleSpinBox" name="doubleSpinBox_ddi_radius">
+           <property name="maximum">
+            <double>1000000.000000000000000</double>
+           </property>
+          </widget>
+         </item>
+         <item row="18" column="0">
+          <layout class="QGridLayout" name="gridLayout_8">
+           <item row="0" column="0">
+            <spacer name="horizontalSpacer_9">
+             <property name="orientation">
+              <enum>Qt::Horizontal</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>40</width>
+               <height>20</height>
+              </size>
+             </property>
+            </spacer>
+           </item>
+           <item row="0" column="1">
+            <widget class="QLabel" name="label_7">
+             <property name="text">
+              <string>cutoff radius</string>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </item>
+         <item row="4" column="2">
+          <spacer name="horizontalSpacer_31">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>40</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+         <item row="16" column="1">
+          <widget class="QComboBox" name="comboBox_ddi_method">
+           <item>
+            <property name="text">
+             <string>FFT</string>
+            </property>
+           </item>
+           <item>
+            <property name="text">
+             <string>FMM</string>
+            </property>
+           </item>
+           <item>
+            <property name="text">
+             <string>Cutoff</string>
+            </property>
+           </item>
+          </widget>
+         </item>
+         <item row="12" column="1">
           <layout class="QGridLayout" name="gridLayout_5">
            <item row="0" column="1">
             <widget class="QComboBox" name="comboBox_dmi_chirality">
@@ -133,14 +407,160 @@
            </item>
           </layout>
          </item>
-         <item row="10" column="0">
+         <item row="15" column="1">
+          <spacer name="verticalSpacer_7">
+           <property name="orientation">
+            <enum>Qt::Vertical</enum>
+           </property>
+           <property name="sizeType">
+            <enum>QSizePolicy::Fixed</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>20</width>
+             <height>10</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+         <item row="9" column="1">
+          <spacer name="verticalSpacer_6">
+           <property name="orientation">
+            <enum>Qt::Vertical</enum>
+           </property>
+           <property name="sizeType">
+            <enum>QSizePolicy::Fixed</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>20</width>
+             <height>10</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+         <item row="4" column="0">
+          <widget class="QCheckBox" name="checkBox_extH_aniso">
+           <property name="text">
+            <string>External Field</string>
+           </property>
+           <property name="checked">
+            <bool>false</bool>
+           </property>
+           <property name="tristate">
+            <bool>false</bool>
+           </property>
+          </widget>
+         </item>
+         <item row="7" column="0">
           <widget class="QCheckBox" name="checkBox_ani_aniso">
            <property name="text">
             <string>Anisotropy</string>
            </property>
           </widget>
          </item>
-         <item row="13" column="1">
+         <item row="19" column="0">
+          <layout class="QGridLayout" name="gridLayout_9">
+           <item row="0" column="0">
+            <spacer name="horizontalSpacer_10">
+             <property name="orientation">
+              <enum>Qt::Horizontal</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>40</width>
+               <height>20</height>
+              </size>
+             </property>
+            </spacer>
+           </item>
+           <item row="0" column="1">
+            <widget class="QLabel" name="label_8">
+             <property name="text">
+              <string>PB zero padding</string>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </item>
+         <item row="10" column="0">
+          <widget class="QCheckBox" name="checkBox_exchange">
+           <property name="text">
+            <string>Exchange</string>
+           </property>
+          </widget>
+         </item>
+         <item row="6" column="1">
+          <spacer name="verticalSpacer_5">
+           <property name="orientation">
+            <enum>Qt::Vertical</enum>
+           </property>
+           <property name="sizeType">
+            <enum>QSizePolicy::Fixed</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>20</width>
+             <height>10</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+         <item row="8" column="0">
+          <layout class="QGridLayout" name="gridLayout_46">
+           <item row="0" column="1">
+            <widget class="QLabel" name="label_21">
+             <property name="text">
+              <string>Direction (x,y,z)</string>
+             </property>
+            </widget>
+           </item>
+           <item row="0" column="0">
+            <spacer name="horizontalSpacer_36">
+             <property name="orientation">
+              <enum>Qt::Horizontal</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>30</width>
+               <height>20</height>
+              </size>
+             </property>
+            </spacer>
+           </item>
+          </layout>
+         </item>
+         <item row="14" column="1">
+          <layout class="QGridLayout" name="gridLayout_dmi">
+           <item row="0" column="2">
+            <spacer name="horizontalSpacer_6">
+             <property name="orientation">
+              <enum>Qt::Horizontal</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>40</width>
+               <height>20</height>
+              </size>
+             </property>
+            </spacer>
+           </item>
+           <item row="0" column="0">
+            <widget class="QLabel" name="label_4">
+             <property name="text">
+              <string>Number of Shells</string>
+             </property>
+            </widget>
+           </item>
+           <item row="0" column="1">
+            <widget class="QSpinBox" name="spinBox_nshells_dmi"/>
+           </item>
+          </layout>
+         </item>
+         <item row="19" column="1">
+          <widget class="QCheckBox" name="checkBox_ddi_pb_zero_padding"/>
+         </item>
+         <item row="10" column="1">
           <layout class="QGridLayout" name="gridLayout_exchange">
            <item row="0" column="1">
             <widget class="QSpinBox" name="spinBox_nshells_exchange"/>
@@ -167,180 +587,7 @@
            </item>
           </layout>
          </item>
-         <item row="11" column="0">
-          <layout class="QGridLayout" name="gridLayout_46">
-           <item row="0" column="1">
-            <widget class="QLabel" name="label_21">
-             <property name="text">
-              <string>Direction (x,y,z)</string>
-             </property>
-            </widget>
-           </item>
-           <item row="0" column="0">
-            <spacer name="horizontalSpacer_36">
-             <property name="orientation">
-              <enum>Qt::Horizontal</enum>
-             </property>
-             <property name="sizeHint" stdset="0">
-              <size>
-               <width>30</width>
-               <height>20</height>
-              </size>
-             </property>
-            </spacer>
-           </item>
-          </layout>
-         </item>
-         <item row="12" column="1">
-          <spacer name="verticalSpacer_6">
-           <property name="orientation">
-            <enum>Qt::Vertical</enum>
-           </property>
-           <property name="sizeType">
-            <enum>QSizePolicy::Fixed</enum>
-           </property>
-           <property name="sizeHint" stdset="0">
-            <size>
-             <width>20</width>
-             <height>10</height>
-            </size>
-           </property>
-          </spacer>
-         </item>
-         <item row="9" column="1">
-          <spacer name="verticalSpacer_5">
-           <property name="orientation">
-            <enum>Qt::Vertical</enum>
-           </property>
-           <property name="sizeType">
-            <enum>QSizePolicy::Fixed</enum>
-           </property>
-           <property name="sizeHint" stdset="0">
-            <size>
-             <width>20</width>
-             <height>10</height>
-            </size>
-           </property>
-          </spacer>
-         </item>
-         <item row="7" column="0">
-          <widget class="QCheckBox" name="checkBox_extH_aniso">
-           <property name="text">
-            <string>External Field</string>
-           </property>
-           <property name="checked">
-            <bool>false</bool>
-           </property>
-           <property name="tristate">
-            <bool>false</bool>
-           </property>
-          </widget>
-         </item>
-         <item row="7" column="2">
-          <spacer name="horizontalSpacer_31">
-           <property name="orientation">
-            <enum>Qt::Horizontal</enum>
-           </property>
-           <property name="sizeHint" stdset="0">
-            <size>
-             <width>40</width>
-             <height>20</height>
-            </size>
-           </property>
-          </spacer>
-         </item>
-         <item row="15" column="0">
-          <widget class="QCheckBox" name="checkBox_dmi">
-           <property name="text">
-            <string>DMI</string>
-           </property>
-          </widget>
-         </item>
-         <item row="1" column="0">
-          <widget class="QCheckBox" name="checkBox_aniso_periodical_a">
-           <property name="text">
-            <string>Periodical a</string>
-           </property>
-          </widget>
-         </item>
-         <item row="11" column="1">
-          <layout class="QGridLayout" name="gridLayout_47">
-           <item row="0" column="0">
-            <widget class="QLineEdit" name="lineEdit_anix_aniso">
-             <property name="maximumSize">
-              <size>
-               <width>40</width>
-               <height>16777215</height>
-              </size>
-             </property>
-            </widget>
-           </item>
-           <item row="0" column="1">
-            <widget class="QLineEdit" name="lineEdit_aniy_aniso">
-             <property name="maximumSize">
-              <size>
-               <width>40</width>
-               <height>16777215</height>
-              </size>
-             </property>
-            </widget>
-           </item>
-           <item row="0" column="2">
-            <widget class="QLineEdit" name="lineEdit_aniz_aniso">
-             <property name="maximumSize">
-              <size>
-               <width>40</width>
-               <height>16777215</height>
-              </size>
-             </property>
-            </widget>
-           </item>
-           <item row="0" column="3">
-            <spacer name="horizontalSpacer_35">
-             <property name="orientation">
-              <enum>Qt::Horizontal</enum>
-             </property>
-             <property name="sizeHint" stdset="0">
-              <size>
-               <width>40</width>
-               <height>20</height>
-              </size>
-             </property>
-            </spacer>
-           </item>
-          </layout>
-         </item>
-         <item row="13" column="0">
-          <widget class="QCheckBox" name="checkBox_exchange">
-           <property name="text">
-            <string>Exchange</string>
-           </property>
-          </widget>
-         </item>
-         <item row="18" column="1">
-          <spacer name="verticalSpacer_7">
-           <property name="orientation">
-            <enum>Qt::Vertical</enum>
-           </property>
-           <property name="sizeType">
-            <enum>QSizePolicy::Fixed</enum>
-           </property>
-           <property name="sizeHint" stdset="0">
-            <size>
-             <width>20</width>
-             <height>10</height>
-            </size>
-           </property>
-          </spacer>
-         </item>
-         <item row="5" column="0">
-          <widget class="QCheckBox" name="checkBox_aniso_periodical_c">
-           <property name="text">
-            <string>Periodical c</string>
-           </property>
-          </widget>
-         </item>
-         <item row="7" column="1">
+         <item row="4" column="1">
           <layout class="QGridLayout" name="gridLayout_36">
            <item row="0" column="1">
             <widget class="QLineEdit" name="lineEdit_extH_aniso">
@@ -364,291 +611,6 @@
               </size>
              </property>
             </spacer>
-           </item>
-          </layout>
-         </item>
-         <item row="14" column="1">
-          <spacer name="verticalSpacer_9">
-           <property name="orientation">
-            <enum>Qt::Vertical</enum>
-           </property>
-           <property name="sizeType">
-            <enum>QSizePolicy::Fixed</enum>
-           </property>
-           <property name="sizeHint" stdset="0">
-            <size>
-             <width>20</width>
-             <height>10</height>
-            </size>
-           </property>
-          </spacer>
-         </item>
-         <item row="19" column="0">
-          <widget class="QCheckBox" name="checkBox_ddi">
-           <property name="text">
-            <string>Dipole-dipole</string>
-           </property>
-          </widget>
-         </item>
-         <item row="8" column="1">
-          <layout class="QGridLayout" name="gridLayout_32">
-           <item row="1" column="1">
-            <widget class="QLineEdit" name="lineEdit_extHx_aniso">
-             <property name="maximumSize">
-              <size>
-               <width>40</width>
-               <height>16777215</height>
-              </size>
-             </property>
-            </widget>
-           </item>
-           <item row="1" column="2">
-            <widget class="QLineEdit" name="lineEdit_extHy_aniso">
-             <property name="maximumSize">
-              <size>
-               <width>40</width>
-               <height>16777215</height>
-              </size>
-             </property>
-            </widget>
-           </item>
-           <item row="1" column="5">
-            <spacer name="horizontalSpacer_24">
-             <property name="orientation">
-              <enum>Qt::Horizontal</enum>
-             </property>
-             <property name="sizeHint" stdset="0">
-              <size>
-               <width>40</width>
-               <height>20</height>
-              </size>
-             </property>
-            </spacer>
-           </item>
-           <item row="1" column="3">
-            <widget class="QLineEdit" name="lineEdit_extHz_aniso">
-             <property name="maximumSize">
-              <size>
-               <width>40</width>
-               <height>16777215</height>
-              </size>
-             </property>
-            </widget>
-           </item>
-           <item row="0" column="1">
-            <widget class="QLineEdit" name="lineEdit_muSpin_aniso">
-             <property name="maximumSize">
-              <size>
-               <width>40</width>
-               <height>16777215</height>
-              </size>
-             </property>
-            </widget>
-           </item>
-          </layout>
-         </item>
-         <item row="6" column="1">
-          <spacer name="verticalSpacer_4">
-           <property name="orientation">
-            <enum>Qt::Vertical</enum>
-           </property>
-           <property name="sizeType">
-            <enum>QSizePolicy::Fixed</enum>
-           </property>
-           <property name="sizeHint" stdset="0">
-            <size>
-             <width>20</width>
-             <height>10</height>
-            </size>
-           </property>
-          </spacer>
-         </item>
-         <item row="8" column="0">
-          <layout class="QGridLayout" name="gridLayout_40">
-           <item row="2" column="0">
-            <spacer name="horizontalSpacer_32">
-             <property name="orientation">
-              <enum>Qt::Horizontal</enum>
-             </property>
-             <property name="sizeType">
-              <enum>QSizePolicy::Minimum</enum>
-             </property>
-             <property name="sizeHint" stdset="0">
-              <size>
-               <width>30</width>
-               <height>20</height>
-              </size>
-             </property>
-            </spacer>
-           </item>
-           <item row="2" column="1">
-            <widget class="QLabel" name="label_15">
-             <property name="maximumSize">
-              <size>
-               <width>100</width>
-               <height>16777215</height>
-              </size>
-             </property>
-             <property name="text">
-              <string>Direction (x,y,z)</string>
-             </property>
-            </widget>
-           </item>
-           <item row="1" column="1">
-            <widget class="QLabel" name="label_25">
-             <property name="text">
-              <string>mu_spin</string>
-             </property>
-            </widget>
-           </item>
-          </layout>
-         </item>
-         <item row="4" column="0">
-          <widget class="QCheckBox" name="checkBox_aniso_periodical_b">
-           <property name="text">
-            <string>Periodical b</string>
-           </property>
-          </widget>
-         </item>
-         <item row="10" column="1">
-          <layout class="QGridLayout" name="gridLayout_42">
-           <item row="0" column="0">
-            <widget class="QLineEdit" name="lineEdit_ani_aniso">
-             <property name="maximumSize">
-              <size>
-               <width>40</width>
-               <height>16777215</height>
-              </size>
-             </property>
-            </widget>
-           </item>
-           <item row="0" column="1">
-            <spacer name="horizontalSpacer_29">
-             <property name="orientation">
-              <enum>Qt::Horizontal</enum>
-             </property>
-             <property name="sizeHint" stdset="0">
-              <size>
-               <width>40</width>
-               <height>20</height>
-              </size>
-             </property>
-            </spacer>
-           </item>
-          </layout>
-         </item>
-         <item row="19" column="1">
-          <widget class="QComboBox" name="comboBox_ddi_method">
-           <item>
-            <property name="text">
-             <string>FFT</string>
-            </property>
-           </item>
-           <item>
-            <property name="text">
-             <string>FMM</string>
-            </property>
-           </item>
-           <item>
-            <property name="text">
-             <string>Cutoff</string>
-            </property>
-           </item>
-          </widget>
-         </item>
-         <item row="20" column="1">
-          <layout class="QGridLayout" name="gridLayout_6">
-           <item row="0" column="0">
-            <widget class="QSpinBox" name="spinBox_ddi_n_periodic_a"/>
-           </item>
-           <item row="0" column="1">
-            <widget class="QSpinBox" name="spinBox_ddi_n_periodic_b"/>
-           </item>
-           <item row="0" column="2">
-            <widget class="QSpinBox" name="spinBox_ddi_n_periodic_c"/>
-           </item>
-          </layout>
-         </item>
-         <item row="21" column="1">
-          <widget class="QDoubleSpinBox" name="doubleSpinBox_ddi_radius">
-           <property name="maximum">
-             <double>1000000.000000000000000</double>
-           </property>
-          </widget>
-          </item>
-          <item row="22" column="1">
-              <widget class="QCheckBox" name="checkBox_ddi_pb_zero_padding">
-              </widget>
-         </item>
-         <item row="20" column="0">
-          <layout class="QGridLayout" name="gridLayout_7">
-           <item row="0" column="0">
-            <spacer name="horizontalSpacer_8">
-             <property name="orientation">
-              <enum>Qt::Horizontal</enum>
-             </property>
-             <property name="sizeHint" stdset="0">
-              <size>
-               <width>40</width>
-               <height>20</height>
-              </size>
-             </property>
-            </spacer>
-           </item>
-           <item row="0" column="1">
-            <widget class="QLabel" name="label_6">
-             <property name="text">
-              <string>periodic images</string>
-             </property>
-            </widget>
-           </item>
-          </layout>
-         </item>
-         <item row="21" column="0">
-          <layout class="QGridLayout" name="gridLayout_8">
-           <item row="0" column="0">
-            <spacer name="horizontalSpacer_9">
-             <property name="orientation">
-              <enum>Qt::Horizontal</enum>
-             </property>
-             <property name="sizeHint" stdset="0">
-              <size>
-               <width>40</width>
-               <height>20</height>
-              </size>
-             </property>
-            </spacer>
-           </item>
-           <item row="0" column="1">
-            <widget class="QLabel" name="label_7">
-             <property name="text">
-              <string>cutoff radius</string>
-             </property>
-            </widget>
-           </item>
-          </layout>
-         </item>
-         <item row="22" column="0">
-          <layout class="QGridLayout" name="gridLayout_9">
-           <item row="0" column="0">
-            <spacer name="horizontalSpacer_10">
-             <property name="orientation">
-              <enum>Qt::Horizontal</enum>
-             </property>
-             <property name="sizeHint" stdset="0">
-              <size>
-               <width>40</width>
-               <height>20</height>
-              </size>
-             </property>
-            </spacer>
-           </item>
-           <item row="0" column="1">
-            <widget class="QLabel" name="label_8">
-             <property name="text">
-              <string>PB zero padding</string>
-             </property>
-            </widget>
            </item>
           </layout>
          </item>
@@ -925,9 +887,6 @@ i  j  k  l   da_j  db_j  dc_j   da_k  db_k  dc_k   da_l  db_l  dc_l   Q</string>
  <tabstops>
   <tabstop>scrollArea_5</tabstop>
   <tabstop>comboBox_Hamiltonian_Ani_ApplyTo</tabstop>
-  <tabstop>checkBox_aniso_periodical_a</tabstop>
-  <tabstop>checkBox_aniso_periodical_b</tabstop>
-  <tabstop>checkBox_aniso_periodical_c</tabstop>
   <tabstop>checkBox_extH_aniso</tabstop>
   <tabstop>lineEdit_extH_aniso</tabstop>
   <tabstop>lineEdit_muSpin_aniso</tabstop>

--- a/ui-cpp/ui-qt/ui/ParametersWidget.ui
+++ b/ui-cpp/ui-qt/ui/ParametersWidget.ui
@@ -83,15 +83,15 @@
           </size>
          </property>
          <property name="currentIndex">
-          <number>2</number>
+          <number>0</number>
          </property>
          <widget class="QWidget" name="page_3">
           <property name="geometry">
            <rect>
             <x>0</x>
             <y>0</y>
-            <width>533</width>
-            <height>684</height>
+            <width>483</width>
+            <height>662</height>
            </rect>
           </property>
           <property name="sizePolicy">
@@ -426,6 +426,27 @@
               </item>
               <item row="5" column="1">
                <layout class="QGridLayout" name="gridLayout_65">
+                <item row="0" column="3">
+                 <layout class="QGridLayout" name="gridLayout_16">
+                  <item row="0" column="0">
+                   <widget class="QComboBox" name="comboBox_spin_current_model">
+                    <property name="editable">
+                     <bool>false</bool>
+                    </property>
+                    <item>
+                     <property name="text">
+                      <string>Monolayer</string>
+                     </property>
+                    </item>
+                    <item>
+                     <property name="text">
+                      <string>Gradient</string>
+                     </property>
+                    </item>
+                   </widget>
+                  </item>
+                 </layout>
+                </item>
                 <item row="0" column="1">
                  <widget class="QDoubleSpinBox" name="doubleSpinBox_llg_stt_magnitude">
                   <property name="decimals">
@@ -439,42 +460,21 @@
                   </property>
                  </widget>
                 </item>
-                <item row="0" column="3">
+                <item row="0" column="2">
                  <spacer name="horizontalSpacer_46">
                   <property name="orientation">
                    <enum>Qt::Horizontal</enum>
                   </property>
+                  <property name="sizeType">
+                   <enum>QSizePolicy::Fixed</enum>
+                  </property>
                   <property name="sizeHint" stdset="0">
                    <size>
-                    <width>40</width>
+                    <width>20</width>
                     <height>20</height>
                    </size>
                   </property>
                  </spacer>
-                </item>
-                <item row="0" column="2">
-                 <layout class="QGridLayout" name="gridLayout_16">
-                  <item row="0" column="0">
-                   <widget class="QRadioButton" name="radioButton_stt_gradient">
-                    <property name="text">
-                     <string>Gradient method</string>
-                    </property>
-                    <property name="checked">
-                     <bool>false</bool>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="1" column="0">
-                   <widget class="QRadioButton" name="radioButton_stt_monolayer">
-                    <property name="text">
-                     <string>Monolayer approximation</string>
-                    </property>
-                    <property name="checked">
-                     <bool>true</bool>
-                    </property>
-                   </widget>
-                  </item>
-                 </layout>
                 </item>
                </layout>
               </item>
@@ -842,7 +842,7 @@
             <x>0</x>
             <y>0</y>
             <width>483</width>
-            <height>652</height>
+            <height>662</height>
            </rect>
           </property>
           <property name="sizePolicy">
@@ -1194,7 +1194,7 @@
             <x>0</x>
             <y>0</y>
             <width>469</width>
-            <height>848</height>
+            <height>800</height>
            </rect>
           </property>
           <property name="sizePolicy">
@@ -1813,7 +1813,7 @@
             <x>0</x>
             <y>0</y>
             <width>483</width>
-            <height>652</height>
+            <height>662</height>
            </rect>
           </property>
           <attribute name="label">
@@ -2128,7 +2128,7 @@
             <x>0</x>
             <y>0</y>
             <width>483</width>
-            <height>652</height>
+            <height>662</height>
            </rect>
           </property>
           <attribute name="label">
@@ -2536,7 +2536,7 @@
  <resources/>
  <connections/>
  <buttongroups>
-  <buttongroup name="buttonGroup"/>
   <buttongroup name="buttonGroup_2"/>
+  <buttongroup name="buttonGroup"/>
  </buttongroups>
 </ui>


### PR DESCRIPTION
### Description

Updated the QT and the DearImgui user interfaces:

- Moved boundary conditions into geometry widgets to reflect the data layout in the core library.
- Replaced deprecated spin current API (`Parameter_LLG_Get_STT` etc.) with the`Parameter_LLG_Get_Spin_Current` functions etc. This removes the deprecation warnings, which would previously be logged.
- QT-GUI now uses a ComboBox to select the spin current model.
- Fixed a word duplication in a log message for the `Parameter_LLG_Set_Spin_Current` function.